### PR TITLE
Pin faraday and net http persistent

### DIFF
--- a/airrecord.gemspec
+++ b/airrecord.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'faraday', '= 0.10.0'
-  spec.add_dependency "net-http-persistent", '= 2.9.4'
+  spec.add_dependency 'faraday', '~> 0.10.0'
+  spec.add_dependency "net-http-persistent", '~> 2.9.4'
 
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/airrecord.gemspec
+++ b/airrecord.gemspec
@@ -18,8 +18,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'faraday'
-  spec.add_dependency "net-http-persistent"
+  spec.add_dependency 'faraday', '= 0.10.0'
+  spec.add_dependency "net-http-persistent", '= 2.9.4'
 
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Net HTTP Persistent 3.0.0 is incompatible with Faraday. 3.0.0 was published October 6, 2016.
I decided to pin both faraday and net http persistent as faraday will likely update to accommodate this.

[Old Version](https://github.com/drbrain/net-http-persistent/blob/1dcdf06f111227f0396afd9b12ab94bea2c636e2/lib/net/http/persistent.rb#L482) vs the [New Version](https://github.com/drbrain/net-http-persistent/blob/0e5a8fb8a27deff37247ddb3bc5e6c9e390face5/lib/net/http/persistent.rb#L505) initialize. The change to keywords caused issues.

cc @Sirupsen 

