### PR TITLE
Add missing assertion to 18de25f

### DIFF
--- a/test/associations_test.rb
+++ b/test/associations_test.rb
@@ -59,5 +59,8 @@ class AssociationsTest < MiniTest::Test
     stub_post_request(tea, table: Tea)
 
     tea.create
+
+    stub_find_request(Brew.new({}), table: Brew, id: "rec2")
+    assert_equal 1, tea[:brews].count
   end
 end


### PR DESCRIPTION
In the previous iteration, the test
`AssociationsTest#test_build_association_from_strings` did not perform
any assertions. Which generally is seen as an anti-pattern. These misses
are usually easy to spot using a tool such as `minitest-proveit`[1].

This commit remedies that by adding a simple assertion that the building
of assertions worked out as expected.

[1]: https://github.com/seattlerb/minitest-proveit