### PR TITLE
Add comparison by a table's fields

### DIFF
--- a/lib/airrecord/table.rb
+++ b/lib/airrecord/table.rb
@@ -197,6 +197,10 @@ module Airrecord
       }]
     end
 
+    def ==(other)
+      serializable_fields == other.serializable_fields
+    end
+
     protected
 
     def association(key)

--- a/lib/airrecord/table.rb
+++ b/lib/airrecord/table.rb
@@ -198,7 +198,8 @@ module Airrecord
     end
 
     def ==(other)
-      serializable_fields == other.serializable_fields
+      self.class == other.class &&
+        serializable_fields == other.serializable_fields
     end
 
     protected

--- a/test/table_test.rb
+++ b/test/table_test.rb
@@ -283,4 +283,17 @@ class TableTest < Minitest::Test
     record = first_record
     assert_instance_of Time, record[:created]
   end
+
+  def test_comparison
+    alpha = @table.new(
+      "Name": "Name",
+      "Created": Time.at(0),
+    )
+    beta = @table.new(
+      "Name": "Name",
+      "Created": Time.at(0),
+    )
+
+    assert_equal alpha, beta
+  end
 end

--- a/test/table_test.rb
+++ b/test/table_test.rb
@@ -285,14 +285,8 @@ class TableTest < Minitest::Test
   end
 
   def test_comparison
-    alpha = @table.new(
-      "Name": "Name",
-      "Created": Time.at(0),
-    )
-    beta = @table.new(
-      "Name": "Name",
-      "Created": Time.at(0),
-    )
+    alpha = @table.new("Name": "Name", "Created": Time.at(0))
+    beta = @table.new("Name": "Name", "Created": Time.at(0))
 
     assert_equal alpha, beta
   end

--- a/test/table_test.rb
+++ b/test/table_test.rb
@@ -290,4 +290,11 @@ class TableTest < Minitest::Test
 
     assert_equal alpha, beta
   end
+
+  def test_comparison_different_classes
+    alpha = @table.new("Name": "Name", "Created": Time.at(0))
+    beta = Walrus.new("Name": "Name", "Created": Time.at(0))
+
+    refute_equal alpha, beta
+  end
 end


### PR DESCRIPTION
This commit introduces the comparison operator, `#==`, to
`Airrecord::Table`. And it does the compassion two-fold: partly my asserting the two classes are the same, and secondly by comparing the two `Airrecord::Table#serializable_fields`'s.