### PR TITLE
Allow input of associated values in non-array form

### DIFF
--- a/lib/airrecord/table.rb
+++ b/lib/airrecord/table.rb
@@ -186,17 +186,18 @@ module Airrecord
 
     def serializable_fields(fields = self.fields)
       Hash[fields.map { |(key, value)|
-        if association(key)
-          assocs = value.map { |assoc|
-            assoc.respond_to?(:id) ? assoc.id : assoc
-          }
-          [key, assocs]
-        else
-          [key, value]
-        end
-      }]
+             if association(key)
+               value = [value] unless value.respond_to?(:map)
+               assocs = value.map { |assoc|
+                 assoc.respond_to?(:id) ? assoc.id : assoc
+               }               
+               [key, assocs]
+             else
+               [key, value]
+             end
+           }]
     end
-
+    
     def ==(other)
       self.class == other.class &&
         serializable_fields == other.serializable_fields

--- a/lib/airrecord/table.rb
+++ b/lib/airrecord/table.rb
@@ -186,16 +186,16 @@ module Airrecord
 
     def serializable_fields(fields = self.fields)
       Hash[fields.map { |(key, value)|
-             if association(key)
-               value = [value] unless value.respond_to?(:map)
-               assocs = value.map { |assoc|
-                 assoc.respond_to?(:id) ? assoc.id : assoc
-               }               
-               [key, assocs]
-             else
-               [key, value]
-             end
-           }]
+        if association(key)
+          value = Array.new {value} unless value.is_a?(Enumerable)
+          assocs = value.map { |assoc|
+            assoc.respond_to?(:id) ? assoc.id : assoc
+          }               
+          [key, assocs]
+        else
+          [key, value]
+        end
+        }]
     end
     
     def ==(other)

--- a/test/table_test.rb
+++ b/test/table_test.rb
@@ -4,6 +4,15 @@ require 'test_helper'
 class Walrus < Airrecord::Table
   self.base_key = 'app1'
   self.table_name = 'walruses'
+
+  has_many :feet, class: 'Foot', column: 'Feet'
+end
+
+class Foot < Airrecord::Table
+  self.base_key = 'app1'
+  self.table_name = 'foot'
+
+  belongs_to :walrus, class: 'Walrus', column: 'Walrus'
 end
 
 class TableTest < Minitest::Test
@@ -296,5 +305,12 @@ class TableTest < Minitest::Test
     beta = Walrus.new("Name": "Name", "Created": Time.at(0))
 
     refute_equal alpha, beta
+  end
+
+  def test_association_accepts_non_enumerable
+    walrus = Walrus.new("Name": "Wally")    
+    foot = Foot.new("Name": "FrontRight", "walrus": walrus)
+
+    foot.serializable_fields
   end
 end


### PR DESCRIPTION
I want to resolve #11 in the safest way. Basically puts single element associations into an array. I did attempt to pass just the item id without an array but it seems the code expects an array in other locations as well. This should enable people to pass single items as the readme suggests and have it work fine.