### PR TITLE
Don't convert association to an empty Array

### DIFF
--- a/lib/airrecord/table.rb
+++ b/lib/airrecord/table.rb
@@ -187,7 +187,7 @@ module Airrecord
     def serializable_fields(fields = self.fields)
       Hash[fields.map { |(key, value)|
         if association(key)
-          value = Array.new {value} unless value.is_a?(Enumerable)
+          value = [ value ] unless value.is_a?(Enumerable)
           assocs = value.map { |assoc|
             assoc.respond_to?(:id) ? assoc.id : assoc
           }               


### PR DESCRIPTION
Before I made this change `Array.new { value }` was just converting my value to an empty Array. Sorry - don't have time to add any tests right now.