### PR TITLE
Add rate limits between requests

### DIFF
--- a/airrecord.gemspec
+++ b/airrecord.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'faraday', '~> 0.10'
+  spec.add_dependency 'faraday-rate_limiter', '~> 0.0.4'
   spec.add_dependency "net-http-persistent", '~> 2.9'
 
   spec.add_development_dependency "bundler", "~> 1.12"

--- a/lib/airrecord/client.rb
+++ b/lib/airrecord/client.rb
@@ -14,6 +14,7 @@ module Airrecord
         "Authorization" => "Bearer #{api_key}",
         "X-API-VERSION" => "0.1.0",
       }) { |conn|
+        conn.request :rate_limiter, interval: 0.20
         conn.adapter :net_http_persistent
       }
     end


### PR DESCRIPTION
Found a small Faraday middleware that limits requests to 5 per second. Hope it helps!

It keeps track of time since last request and sleeps the necessary amount:
https://github.com/cameron-martin/faraday-rate_limiter/blob/140337a89391c675899cc734809a9680216ef521/lib/faraday/rate_limiter.rb#L14

I'll be testing it this weekend. It might be a good idea to make the interval 0.21+ seconds just in case.