### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ class Tea < Airrecord::Table
   has_many :brews, class: 'Brew', column: "Brews"
 
   def self.chinese
-    all(filter: '{Country} == "China"')
+    all(filter: '{Country} = "China"')
   end
 
   def self.cheapest_and_best


### PR DESCRIPTION
Airtable uses one `=` in the `equal to` logical operator.
Using `==` will produce the following error:
```HTTP 422: INVALID_FILTER_BY_FORMULA```

Reference: https://support.airtable.com/hc/en-us/articles/203255215-Formula-Field-Reference#logical