### PR TITLE
Add support for multiple parameters ordering. 

### DIFF
--- a/lib/airrecord/table.rb
+++ b/lib/airrecord/table.rb
@@ -44,12 +44,12 @@ module Airrecord
       end
 
       def records(filter: nil, sort: nil, view: nil, offset: nil, paginate: true, fields: nil, max_records: nil, page_size: nil)
-        options = {}
+        options = {}.compare_by_identity
         options[:filterByFormula] = filter if filter
 
         if sort
-          options[:sort] = sort.map { |field, direction|
-            { field: field.to_s, direction: direction }
+          sort.each { |field, direction|
+            options["sort"] = [{ field: field.to_s, direction: direction }]
           }
         end
 

--- a/lib/airrecord/table.rb
+++ b/lib/airrecord/table.rb
@@ -77,9 +77,9 @@ module Airrecord
         options[:filterByFormula] = filter if filter
 
         if sort
-          options[:sort] = sort.map { |field, direction|
+          sort.each { |field, direction|
             deprecate_symbols if field.is_a? Symbol
-            { field: field.to_s, direction: direction }
+            options["sort"] = [{ field: field.to_s, direction: direction }]
           }
         end
 


### PR DESCRIPTION
It seems that the airtable expects multiple occurrences of the sort parameter in an API call per sort instruction, instead of one sort key pointing to an array of sort directives. See https://codepen.io/airtable/full/rLKkYB where you can generate an example URL.

P.S I tried to write a test for the introduced case, but your approach and setup is so much different to mine. The test would be so much easier (if possible) if you leveraged Webmock. The assertion could be made on the generated and suppressed request URL, fired up by Faraday.