### PR TITLE
add eql? and hash methods to table object for using objects as hash keys

### DIFF
--- a/lib/airrecord/table.rb
+++ b/lib/airrecord/table.rb
@@ -196,17 +196,25 @@ module Airrecord
           value = [ value ] unless value.is_a?(Enumerable)
           assocs = value.map { |assoc|
             assoc.respond_to?(:id) ? assoc.id : assoc
-          }               
+          }
           [key, assocs]
         else
           [key, value]
         end
         }]
     end
-    
+
     def ==(other)
       self.class == other.class &&
         serializable_fields == other.serializable_fields
+    end
+
+    def eql?(other)
+      self == other
+    end
+
+    def hash
+      serializable_fields.hash
     end
 
     protected

--- a/lib/airrecord/table.rb
+++ b/lib/airrecord/table.rb
@@ -209,9 +209,7 @@ module Airrecord
         serializable_fields == other.serializable_fields
     end
 
-    def eql?(other)
-      self == other
-    end
+    alias_method :eql?, :==
 
     def hash
       serializable_fields.hash

--- a/test/table_test.rb
+++ b/test/table_test.rb
@@ -308,7 +308,7 @@ class TableTest < Minitest::Test
   end
 
   def test_association_accepts_non_enumerable
-    walrus = Walrus.new("Name": "Wally")    
+    walrus = Walrus.new("Name": "Wally")
     foot = Foot.new("Name": "FrontRight", "walrus": walrus)
 
     foot.serializable_fields
@@ -318,5 +318,33 @@ class TableTest < Minitest::Test
     walrus = Walrus.new("Name": "Wally")
     walrus[:name] = "Wally"
     assert walrus.updated_keys.empty?
+  end
+
+  def test_equivalent_records_are_eql?
+    walrus1 = Walrus.new("Name": "Wally")
+    walrus2 = Walrus.new("Name": "Wally")
+
+    assert walrus1.eql? walrus2
+  end
+
+  def test_non_equivalent_records_fail_eql?
+    walrus1 = Walrus.new("Name": "Wally")
+    walrus2 = Walrus.new("Name": "Wally2")
+
+    assert !walrus1.eql?(walrus2)
+  end
+
+  def test_equivalent_hash_equality
+    walrus1 = Walrus.new("Name": "Wally")
+    walrus2 = Walrus.new("Name": "Wally")
+
+    assert_equal walrus1.hash, walrus2.hash
+  end
+
+  def test_non_equivalent_hash_inequality
+    walrus1 = Walrus.new("Name": "Wally")
+    walrus2 = Walrus.new("Name": "Wally2")
+
+    assert walrus1.hash != walrus2.hash
   end
 end


### PR DESCRIPTION
this makes airrecord objects usable as hash keys, before this change, each new add creates distinct key entries (unless it is the same _actual_ ruby object).

This may not be wanted behaviour, but it should still detect records with dirty fields (serializable_fields.hash) and return not equal

Cheers for the library!