### PR TITLE
Implement associations as instance methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # 1.0.0 (unreleased)
 
 * 1.0.0 will introduce breaking changes, including removing support for symbols. To update, change snake-case symbols to their correct column names (for example, `record["First Name"]` instead of `record[:first_name]`)
+* Implement associations as instance methods, e.g.
+    ```ruby
+    tea.brews #=> [<Brew>, <Brew>] returns associated models
+    tea["Brews"] #=> ["rec456", "rec789"] returns a raw Airtable field
+    ```
 
 # 0.2.5
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ class Tea < Airrecord::Table
   self.base_key = "app1"
   self.table_name = "Teas"
 
-  has_many "Brews", class: 'Brew', column: "Brews"
+  has_many :brews, class: "Brew", column: "Brews"
 
   def self.chinese
     all(filter: '{Country} = "China"')
@@ -43,7 +43,7 @@ class Brew < Airrecord::Table
   self.base_key = "app1"
   self.table_name = "Brews"
 
-  belongs_to "Tea", class: 'Tea', column: 'Tea'
+  belongs_to :tea, class: "Tea", column: "Tea"
 
   def self.hot
     all(filter: "{Temperature} > 90")
@@ -58,7 +58,7 @@ teas = Tea.all
 tea = teas.first
 tea["Country"] # access atribute
 tea.location # instance methods
-tea["Brews"] # associated brews
+tea.brews # associated brews
 ```
 
 A short-hand API for definitions and more ad-hoc querying is also available:
@@ -268,14 +268,14 @@ class Tea < Airrecord::Table
   self.base_key = "app1"
   self.table_name = "Teas"
 
-  has_many "Brews", class: 'Brew', column: "Brews"
+  has_many :brews, class: "Brew", column: "Brews"
 end
 
 class Brew < Airrecord::Table
   self.base_key = "app1"
   self.table_name = "Brews"
 
-  belongs_to "Tea", class: 'Tea', column: 'Tea'
+  belongs_to :tea, class: "Tea", column: "Tea"
 end
 ```
 
@@ -289,15 +289,21 @@ _not_ support associations across Bases.
 To retrieve records from associations to a record:
 
 ```ruby
-tea = Tea.find('rec84')
-tea["Brews"] # brews associated with tea
+tea = Tea.find("rec123")
+
+# tea.brews returns brews associated with tea
+tea.brews #=> [<Brew>, <Brew>]
+
+# tea["Brews"] returns the raw Airtable field, an array of IDs
+tea["Brews"] #=> ["rec456", "rec789"]
 ```
 
 This in turn works the other way too:
 
 ```ruby
-brew = Brew.find('rec849')
-brew["Tea"] # the associated tea instance
+brew = Brew.find('rec456')
+brew.tea #=> <Tea> the associated tea instance
+brew["Tea"] #=> the raw Airtable field, a single-item array ["rec123"]
 ```
 
 ### Creating associated records
@@ -305,9 +311,18 @@ brew["Tea"] # the associated tea instance
 You can easily associate records with each other:
 
 ```ruby
-tea = Tea.find('rec849829')
+tea = Tea.find("rec123")
 # This will create a brew associated with the specific tea
-brew = Brew.new("Tea" => tea, "Temperature" => "80", "Time" => "4m", "Rating" => "5")
+brew = Brew.new("Temperature" => "80", "Time" => "4m", "Rating" => "5")
+brew.tea = tea
+brew.create
+```
+
+Alternatively, you can specify association ids directly:
+
+```ruby
+tea = Tea.find("rec123")
+brew = Brew.new("Tea" => [tea.id], "Temperature" => "80", "Time" => "4m", "Rating" => "5")
 brew.create
 ```
 

--- a/README.md
+++ b/README.md
@@ -115,10 +115,17 @@ end
 This gives us a class that maps to records in a table. Class methods are
 available to fetch records on the table.
 
+### Reading a Single Record
+
+Retrieve a single record via `#find`:
+```ruby
+tea = Tea.find("someid")
+```
+
 ### Listing Records
 
-Retrieval of multiple records is done through `#all`. To get all records in a
-table:
+Retrieval of multiple records is usually done through `#all`. To get all records
+in a table:
 
 ```ruby
 Tea.all # array of Tea instances
@@ -181,6 +188,14 @@ Tea.all(paginate: false)
 
 # Give me only the most recent teas
 Tea.all(sort: { "Created At" => "desc" }, paginate: false)
+```
+
+When you know the IDs of the records you want, and you want them in an ad-hoc
+order, use `#find_many` instead of `#all`:
+
+```ruby
+teas = Tea.find_many(["someid", "anotherid", "yetanotherid"])
+#=> [<Tea @id="someid">,<Tea @id="anotherid">, <Tea @id="yetanotherid">]
 ```
 
 ### Creating
@@ -269,11 +284,19 @@ class Tea < Airrecord::Table
   self.table_name = "Teas"
 
   has_many :brews, class: "Brew", column: "Brews"
+  has_one :teapot, class: "Teapot", column: "Teapot"
 end
 
 class Brew < Airrecord::Table
   self.base_key = "app1"
   self.table_name = "Brews"
+
+  belongs_to :tea, class: "Tea", column: "Tea"
+end
+
+class Teapot < Airrecord::Table
+  self.base_key = "app1"
+  self.table_name = "Teapot"
 
   belongs_to :tea, class: "Tea", column: "Tea"
 end
@@ -291,18 +314,20 @@ To retrieve records from associations to a record:
 ```ruby
 tea = Tea.find("rec123")
 
-# tea.brews returns brews associated with tea
-tea.brews #=> [<Brew>, <Brew>]
+# record.association returns Airrecord instances
+tea.brews #=> [<Brew @id="rec456">, <Brew @id="rec789">]
+tea.teapot #=> <Teapot @id="rec012">
 
-# tea["Brews"] returns the raw Airtable field, an array of IDs
-tea["Brews"] #=> ["rec456", "rec789"]
+# record["Associated Column"] returns the raw Airtable field, an array of IDs
+tea["Brews"] #=> ["rec789", "rec456"]
+tea["Teapot"] #=> ["rec012"]
 ```
 
 This in turn works the other way too:
 
 ```ruby
-brew = Brew.find('rec456')
-brew.tea #=> <Tea> the associated tea instance
+brew = Brew.find("rec456")
+brew.tea #=> <Tea @id="rec123"> the associated tea instance
 brew["Tea"] #=> the raw Airtable field, a single-item array ["rec123"]
 ```
 

--- a/lib/airrecord/table.rb
+++ b/lib/airrecord/table.rb
@@ -41,7 +41,7 @@ module Airrecord
         end
 
         define_method("#{method_name}=".to_sym) do |value|
-          self[options.fetch(:column)] = cast_association(value)
+          self[options.fetch(:column)] = Array(value).map(&:id)
         end
       end
 
@@ -251,10 +251,6 @@ module Airrecord
     def type_cast(value)
       return Time.parse(value + " UTC") if value =~ /\d{4}-\d{2}-\d{2}/
       value
-    end
-
-    def cast_association(value)
-      Array(value).map { |obj| obj&.id || obj }
     end
   end
 

--- a/lib/airrecord/table.rb
+++ b/lib/airrecord/table.rb
@@ -41,7 +41,7 @@ module Airrecord
         end
 
         define_method("#{method_name}=".to_sym) do |value|
-          self[options.fetch(:column)] = Array(value).map(&:id)
+          self[options.fetch(:column)] = Array(value).map(&:id).reverse
         end
       end
 

--- a/lib/airrecord/table.rb
+++ b/lib/airrecord/table.rb
@@ -57,6 +57,12 @@ module Airrecord
         end
       end
 
+      def find_many(ids)
+        or_args = ids.map { |id| "RECORD_ID() = '#{id}'"}.join(',')
+        formula = "OR(#{or_args})"
+        records(filter: formula).sort_by { |record| or_args.index(record.id) }
+      end
+
       def records(filter: nil, sort: nil, view: nil, offset: nil, paginate: true, fields: nil, max_records: nil, page_size: nil)
         options = {}
         options[:filterByFormula] = filter if filter

--- a/lib/airrecord/table.rb
+++ b/lib/airrecord/table.rb
@@ -32,7 +32,6 @@ module Airrecord
       end
 
       def has_many(method_name, options)
-        # define an assocation getter
         define_method(method_name.to_sym) do
           # Get association ids in reverse order, because Airtable’s UI and API
           # sort associations in opposite directions. We want to match the UI.
@@ -41,7 +40,6 @@ module Airrecord
           options[:single] ? table.find(ids.first) : table.find_many(ids)
         end
 
-        # define an assocation setter
         define_method("#{method_name}=".to_sym) do |value|
           self[options.fetch(:column)] = cast_association(value)
         end
@@ -50,6 +48,8 @@ module Airrecord
       def belongs_to(method_name, options)
         has_many(method_name, options.merge(single: true))
       end
+
+      alias has_one belongs_to
 
       def api_key
         @api_key || Airrecord.api_key
@@ -254,8 +254,7 @@ module Airrecord
     end
 
     def cast_association(value)
-      return value.map { |obj| obj&.id || obj } if value.respond_to?(:map)
-      [value&.id || value]
+      Array(value).map { |obj| obj&.id || obj }
     end
   end
 

--- a/test/associations_test.rb
+++ b/test/associations_test.rb
@@ -94,15 +94,20 @@ class AssociationsTest < MiniTest::Test
 
   def test_build_has_many_association_from_setter
     tea = Tea.new("Name" => "Earl Grey")
-    brew = Brew.new("Name" => "Hot")
-    stub_post_request(brew, table: Brew)
-    stubbed_brew_fields = brew.create.merge("id" => brew.id)
+    brews = %w[Perfect Meh].each_with_object([]) do |name, memo|
+      brew = Brew.new("Name" => name)
+      stub_post_request(brew, table: Brew)
+      brew.create
+      memo << brew
+    end
 
-    tea.brews = [brew]
+    tea.brews = brews
 
-    stub_request([stubbed_brew_fields], table: Brew)
-    assert_equal 1, tea.brews.size
+    brew_fields = brews.map { |brew| brew.fields.merge("id" => brew.id) }
+    stub_request(brew_fields, table: Brew)
+
+    assert_equal 2, tea.brews.size
     assert_kind_of Airrecord::Table, tea.brews.first
-    assert_equal tea.brews.first.id, brew.id
+    assert_equal tea.brews.first.id, brews.first.id
   end
 end

--- a/test/associations_test.rb
+++ b/test/associations_test.rb
@@ -6,6 +6,7 @@ class Tea < Airrecord::Table
   self.table_name = "Teas"
 
   has_many :brews, class: "Brew", column: "Brews"
+  has_one :pot, class: "Teapot", column: "Teapot"
 end
 
 class Brew < Airrecord::Table
@@ -15,6 +16,15 @@ class Brew < Airrecord::Table
 
   belongs_to :tea, class: "Tea", column: "Tea"
 end
+
+class Teapot < Airrecord::Table
+  self.api_key = "key1"
+  self.base_key = "app1"
+  self.table_name = "Teapots"
+
+  belongs_to :tea, class: "Tea", column: "Tea"
+end
+
 
 class AssociationsTest < MiniTest::Test
   def setup
@@ -44,6 +54,14 @@ class AssociationsTest < MiniTest::Test
     stub_find_request(tea, table: Tea, id: "rec1")
 
     assert_equal "rec1", brew.tea.id
+  end
+
+  def test_has_one
+    tea = Tea.new("id" => "rec1", "Name" => "Sencha", "Teapot" => ["rec3"])
+    pot = Teapot.new("Name" => "Cast Iron", "Tea" => ["rec1"])
+    stub_find_request(pot, table: Teapot, id: "rec3")
+
+    assert_equal "rec3", tea.pot.id
   end
 
   def test_build_association_from_strings

--- a/test/associations_test.rb
+++ b/test/associations_test.rb
@@ -48,6 +48,12 @@ class AssociationsTest < MiniTest::Test
     assert_equal "rec1", tea.brews.first.id
   end
 
+  def test_has_many_handles_empty_associations
+    tea = Tea.new("Name" => "Gunpowder")
+    stub_request([], table: Brew)
+    assert_equal 0, tea.brews.size
+  end
+
   def test_belongs_to
     brew = Brew.new("Name" => "Good Brew", "Tea" => ["rec1"])
     tea = Tea.new("Name" => "Dong Ding", "Brews" => ["rec2"])

--- a/test/table_test.rb
+++ b/test/table_test.rb
@@ -249,6 +249,11 @@ class TableTest < Minitest::Test
     end
   end
 
+  def test_find_many
+    ids = %w[rec1 rec2 rec3]
+    assert_instance_of Array, @table.find_many(ids)
+  end
+
   def test_destroy_new_record_fails
     record = @table.new("Name" => "walrus")
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,7 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'airrecord'
 require 'byebug'
-
+require 'securerandom'
 require 'minitest/autorun'
 
 class Minitest::Test
@@ -50,7 +50,7 @@ class Minitest::Test
     body = {
       records: records.map { |record|
         {
-          id: SecureRandom.hex(16),
+          id: record["id"] || SecureRandom.hex(16),
           fields: record,
           createdTime: Time.now,
         }


### PR DESCRIPTION
As discussed in [#27](https://github.com/sirupsen/airrecord/issues/27), this patch fixes timeout errors when fetching many associated records, and changes the association API such that associations are accessed via instance methods, instead of via `record[]`.

As I was working through the test suite, @sirupsen, I realized it hadn't occurred to me to consider _setting_ associations as well as getting them. To stay consistent with the proposal for getters, I implemented the following behavior:

```ruby
# you can either set associations via models and setter methods
tea.brews = [<Brew>, <Brew>]
# or you can set associations via raw fields
tea["Brews"] = ["rec456", "rec789"]
```

Happy to rework this if another approach seems better to you.