### PR TITLE
Support multiple sort params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
     tea.brews #=> [<Brew>, <Brew>] returns associated models
     tea["Brews"] #=> ["rec456", "rec789"] returns a raw Airtable field
     ```
+* Fix sorting by multiple fields
 
 # 0.2.5
 

--- a/lib/airrecord/client.rb
+++ b/lib/airrecord/client.rb
@@ -1,4 +1,3 @@
-require 'uri'
 require_relative 'query_string'
 
 module Airrecord
@@ -24,7 +23,7 @@ module Airrecord
     end
 
     def escape(*args)
-      URI.escape(*args)
+      QueryString.escape(*args)
     end
 
     def parse(body)

--- a/lib/airrecord/client.rb
+++ b/lib/airrecord/client.rb
@@ -1,4 +1,5 @@
 require 'uri'
+require_relative 'query_string'
 
 module Airrecord
   class Client
@@ -10,10 +11,14 @@ module Airrecord
     end
 
     def connection
-      @connection ||= Faraday.new(url: "https://api.airtable.com", headers: {
-        "Authorization" => "Bearer #{api_key}",
-        "X-API-VERSION" => "0.1.0",
-      }) { |conn|
+      @connection ||= Faraday.new(
+        url: "https://api.airtable.com",
+        headers: {
+          "Authorization" => "Bearer #{api_key}",
+          "X-API-VERSION" => "0.1.0",
+        },
+        request: { params_encoder: Airrecord::QueryString },
+      ) { |conn|
         conn.adapter :net_http_persistent
       }
     end

--- a/lib/airrecord/query_string.rb
+++ b/lib/airrecord/query_string.rb
@@ -1,0 +1,43 @@
+module Airrecord
+  # The Airtable API expects arrays to be URL-encoded with indices.
+  # Faraday doesn't encode arrays this way, but node's "qs" module does:
+  # https://github.com/ljharb/qs#stringifying
+  #
+  # Airrecord::QueryString makes the qs format available to Faraday
+  module QueryString
+    module_function
+
+    def encode(params)
+      params.map { |key, val| Encodings[val].call(key, val) }.join('&')
+    end
+
+    def decode(query)
+      Faraday::NestedParamsEncoder.decode(query)
+    end
+
+    module Encodings
+      module_function
+
+      def [](value)
+        encoding = "encode_#{value.class}".downcase.to_sym
+        respond_to?(encoding) ? method(encoding) : encode_default
+      end
+
+      def encode_default
+        ->(key, value) { "#{key}=#{value}" }
+      end
+
+      def encode_array(prefix, array)
+        array.each_with_index.map do |value, index|
+          Encodings[value].call("#{prefix}[#{index}]", value)
+        end
+      end
+
+      def encode_hash(prefix, hash)
+        hash.map do |key, value|
+          Encodings[value].call("#{prefix}[#{key}]", value)
+        end
+      end
+    end
+  end
+end

--- a/lib/airrecord/query_string.rb
+++ b/lib/airrecord/query_string.rb
@@ -1,3 +1,5 @@
+require 'erb'
+
 module Airrecord
   # Airtable expects that arrays in query strings be encoded with indices.
   # Faraday follows Rack conventions and encodes arrays _without_ indices.
@@ -13,7 +15,13 @@ module Airrecord
       Faraday::NestedParamsEncoder.decode(query)
     end
 
+    def self.escape(*query)
+      query.map { |qs| ERB::Util.url_encode(qs) }.join('')
+    end
+
     module Encodings
+      using QueryString
+
       def self.[](value)
         TYPES.fetch(value.class, DEFAULT)
       end
@@ -31,7 +39,9 @@ module Airrecord
         },
       }.freeze
 
-      DEFAULT = ->(key, value) { "#{key}=#{value}" }.freeze
+      DEFAULT = lambda do |key, value|
+        "#{QueryString.escape(key)}=#{QueryString.escape(value)}"
+      end
     end
   end
 end

--- a/test/query_string_test.rb
+++ b/test/query_string_test.rb
@@ -1,0 +1,54 @@
+require 'test_helper'
+
+class QueryStringTest < Minitest::Test
+  def setup
+    @params = { maxRecords: 50, view: "Master" }
+  end
+
+  def test_encoding_simple_params_matches_faraday
+    expected = Faraday::NestedParamsEncoder.encode(@params)
+    result = Airrecord::QueryString.encode(@params)
+
+    assert_equal(result, expected)
+  end
+
+  def test_encoding_arrays_uses_indices
+    params = @params.merge(fields: %w[Quality Price])
+
+    expected = "maxRecords=50&view=Master&fields[0]=Quality&fields[1]=Price"
+    result = Airrecord::QueryString.encode(params)
+
+    assert_equal(result, expected)
+  end
+
+  def test_encoding_arrays_of_objects
+    params = { sort: [
+      { field: 'Quality', direction: 'desc' },
+      { field: 'Price', direction: 'asc' }
+    ]}
+
+    expected = 'sort[0][field]=Quality&sort[0][direction]=desc&sort[1][field]=Price&sort[1][direction]=asc'
+    result = Airrecord::QueryString.encode(params)
+
+    assert_equal(result, expected)
+  end
+
+  def test_params_fuzzing
+    params = {
+      "an explicit nil" => nil,
+      horror: [1, 2, [{ mic: "check" }, { one: "two" }]],
+      view: "A name with spaces",
+    }
+
+    expected = {
+      "an explicit nil" => "",
+      "horror" => ["1", "2", [{ "mic" => "check" }, { "one" => "two" }]],
+      "view" => "A name with spaces",
+    }
+    result = Faraday::NestedParamsEncoder.decode(
+      Airrecord::QueryString.encode(params)
+    )
+
+    assert_equal(result, expected)
+  end
+end

--- a/test/query_string_test.rb
+++ b/test/query_string_test.rb
@@ -3,20 +3,29 @@ require 'test_helper'
 class QueryStringTest < Minitest::Test
   def setup
     @params = { maxRecords: 50, view: "Master" }
+    @query = "maxRecords=3&pageSize=1&sort%5B0%5D%5Bfield%5D=Quality&sort%5B0%5D%5Bdirection%5D=asc"
+    @qs = Airrecord::QueryString
   end
 
   def test_encoding_simple_params_matches_faraday
     expected = Faraday::NestedParamsEncoder.encode(@params)
-    result = Airrecord::QueryString.encode(@params)
+    result = @qs.encode(@params)
 
     assert_equal(result, expected)
+  end
+
+  def test_decode_matches_faraday
+    assert_equal(
+      Faraday::NestedParamsEncoder.decode(@query),
+      @qs.decode(@query),
+    )
   end
 
   def test_encoding_arrays_uses_indices
     params = @params.merge(fields: %w[Quality Price])
 
-    expected = "maxRecords=50&view=Master&fields[0]=Quality&fields[1]=Price"
-    result = Airrecord::QueryString.encode(params)
+    expected = "maxRecords=50&view=Master&fields%5B0%5D=Quality&fields%5B1%5D=Price"
+    result = @qs.encode(params)
 
     assert_equal(result, expected)
   end
@@ -27,8 +36,8 @@ class QueryStringTest < Minitest::Test
       { field: 'Price', direction: 'asc' }
     ]}
 
-    expected = 'sort[0][field]=Quality&sort[0][direction]=desc&sort[1][field]=Price&sort[1][direction]=asc'
-    result = Airrecord::QueryString.encode(params)
+    expected = "sort%5B0%5D%5Bfield%5D=Quality&sort%5B0%5D%5Bdirection%5D=desc&sort%5B1%5D%5Bfield%5D=Price&sort%5B1%5D%5Bdirection%5D=asc"
+    result = @qs.encode(params)
 
     assert_equal(result, expected)
   end
@@ -45,10 +54,17 @@ class QueryStringTest < Minitest::Test
       "horror" => ["1", "2", [{ "mic" => "check" }, { "one" => "two" }]],
       "view" => "A name with spaces",
     }
-    result = Faraday::NestedParamsEncoder.decode(
-      Airrecord::QueryString.encode(params)
-    )
+    result = Faraday::NestedParamsEncoder.decode(@qs.encode(params))
 
     assert_equal(result, expected)
+  end
+
+  def test_escaping_one_string
+    assert_equal(@qs.escape("test string"), "test%20string")
+  end
+
+  def test_escaping_many_strings
+    strings = ['test', 'string']
+    assert_equal(@qs.escape(*strings), 'teststring')
   end
 end


### PR DESCRIPTION
As @Meekohi flagged, Airtable's API expects URL query strings to encode arrays with indices. As far as I can tell, Ruby apps almost never encode like this, and it's not an encoding option that Faraday supports by default. But Faraday _does_ support using custom encoders via its `params_encoder` option, which is what the new `Airrecord::QueryString` module is for.

As per @socjopata's suggestion, the unit tests for `QueryString` check actual URL strings against Airtable's spec. I also wrote a tiny test suite against a live Airtable base (not included in this PR), just to confirm that sorting really does work.