### PR TITLE
rate_limit: initial implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,15 @@ end
 Tea.find("rec3838")
 ```
 
+### Throttling
+
+Airtable's API enforces a 5 requests per second limit per client. In most cases,
+you won't reach this limit in a single thread but it's possible for some fast
+calls. Airrecord automatically enforces this limit. It doesn't use a naive
+throttling algorithm that does a `sleep(0.2)` between each call, but rather
+keeps a sliding window of when each call was made and will sleep at the end of
+the window if requires. This means that bursting is supported.
+
 ### Production Middlewares
 
 For production use-cases, it's worth considering adding retries and circuit

--- a/lib/airrecord.rb
+++ b/lib/airrecord.rb
@@ -9,4 +9,10 @@ module Airrecord
   extend self
   Error = Class.new(StandardError)
   attr_accessor :api_key
+  attr_accessor :throttle
+
+  def throttle?
+    return true if @throttle.nil?
+    @throttle
+  end
 end

--- a/lib/airrecord/faraday_rate_limiter.rb
+++ b/lib/airrecord/faraday_rate_limiter.rb
@@ -1,0 +1,60 @@
+require 'thread'
+
+module Airrecord
+  class FaradayRateLimiter < Faraday::Middleware
+    class << self
+      attr_accessor :requests
+    end
+
+    def initialize(app, requests_per_second: nil, sleeper: nil)
+      super(app)
+      @rps = requests_per_second
+      @sleeper = sleeper || ->(seconds) { sleep(seconds) }
+      @mutex = Mutex.new
+      clear
+    end
+
+    def call(env)
+      @mutex.synchronize do
+        wait if too_many_requests_in_last_second?
+        @app.call(env).on_complete do |_response_env|
+          requests << Process.clock_gettime(Process::CLOCK_MONOTONIC)
+          requests.shift if requests.size > @rps
+        end
+      end
+    end
+
+    def clear
+      self.class.requests = []
+    end
+
+    private
+
+    def requests
+      self.class.requests
+    end
+
+    def too_many_requests_in_last_second?
+      return false unless @rps
+      return false unless requests.size >= @rps
+      window_span < 1.0
+    end
+
+    def wait
+      # Time to wait until making the next request to stay within limits.
+      # [1.1, 1.2, 1.3, 1.4, 1.5] => 1 - 0.4 => 0.6
+      wait_time = 1.0 - window_span
+      @sleeper.call(wait_time)
+    end
+
+    # [1.1, 1.2, 1.3, 1.4, 1.5] => 1.5 - 1.1 => 0.4
+    def window_span
+      requests.last - requests.first
+    end
+  end
+end
+
+Faraday::Request.register_middleware(
+  # Avoid polluting the global middleware namespace with a prefix.
+  :airrecord_rate_limiter => Airrecord::FaradayRateLimiter
+)

--- a/test/faraday_rate_limiter_test.rb
+++ b/test/faraday_rate_limiter_test.rb
@@ -1,0 +1,43 @@
+require 'test_helper'
+require 'airrecord/faraday_rate_limiter'
+
+class FaradayRateLimiterTest < Minitest::Test
+  def setup
+    @stubs = Faraday::Adapter::Test::Stubs.new
+    @rps = 5
+    @sleeps = []
+    @connection = Faraday.new { |builder|
+      builder.request :airrecord_rate_limiter,
+        requests_per_second: @rps,
+        sleeper: ->(s) { @sleeps << s }
+
+      builder.adapter :test, @stubs
+    }
+
+    @stubs.get("/whatever") do |env|
+      [200, {}, "walrus"]
+    end
+  end
+
+  def teardown
+    @connection.app.clear
+  end
+
+  def test_passes_through_single_request
+    @connection.get("/whatever")
+    assert_predicate @sleeps, :empty?
+  end
+
+  def test_sleeps_on_the_rps_plus_oneth_request
+    @rps.times do
+      @connection.get("/whatever")
+    end
+
+    assert_predicate @sleeps, :empty?
+
+    @connection.get("/whatever")
+
+    assert_equal 1, @sleeps.size
+    assert @sleeps.first > 0.9
+  end
+end


### PR DESCRIPTION
https://github.com/sirupsen/airrecord/issues/7 https://github.com/sirupsen/airrecord/issues/24

This provides a simple, burstable rate limiter that ensures we're doing only 5 requests per second. In my testing where I get a page of ~100 records, the full roundtrip (including Ruby-time) takes about ~200ms. For quicker quests, e.g. single record lookup, you can likely run into this limit.

The naive solution would be a `sleep 0.2`, but that doesn't properly account for the time it took to process the request _and_ it doesn't provide bursting, i.e. doing 5 quick requests or so without waiting using your 'budget.'

@Meekohi @chrisfrank 