### PR TITLE
date: don't parse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Automatically throttle client calls to Airtable's API limit of 5 requests per second.
 * Fix sorting by multiple fields
 * Report `User-Agent` as `Airrecord`.
+* Dates that are formed `\d{4}-\d{2}-\d{2}` are no longer auto-parsed. Define a helper instead.
 
 # 0.2.5
 

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ class Brew < Airrecord::Table
   end
 
   def done_brewing?
-    self["Created At"] + self["Duration"] > Time.now
+    Time.parse(self["Created At"]) + self["Duration"] > Time.now
   end
 end
 

--- a/lib/airrecord/table.rb
+++ b/lib/airrecord/table.rb
@@ -143,7 +143,7 @@ module Airrecord
         value = fields[column_mappings[key]]
       end
 
-      type_cast(value)
+      value
     end
 
     def []=(key, value)
@@ -252,11 +252,6 @@ module Airrecord
 
     def client
       self.class.client
-    end
-
-    def type_cast(value)
-      return Time.parse(value + " UTC") if value =~ /\d{4}-\d{2}-\d{2}/
-      value
     end
   end
 

--- a/test/table_test.rb
+++ b/test/table_test.rb
@@ -287,11 +287,11 @@ class TableTest < Minitest::Test
     end
   end
 
-  def test_dates_are_type_casted
+  def test_dates_are_not_type_casted
     stub_request([{"Name" => "omg", "Created" => Time.now.to_s}])
 
     record = first_record
-    assert_instance_of Time, record["Created"]
+    assert_instance_of String, record["Created"]
   end
 
   def test_comparison


### PR DESCRIPTION
https://github.com/sirupsen/airrecord/issues/36

@kriskelly @chrisfrank @Meekohi 

Will make it into 1.0.0 since it's not backwards compatible.