### PR TITLE
Drop symbol access to fields

### DIFF
--- a/lib/airrecord/table.rb
+++ b/lib/airrecord/table.rb
@@ -108,6 +108,10 @@ module Airrecord
       !id
     end
 
+    def [](key)
+      fields[key]
+    end
+
     def []=(key, value)
       return if fields[key] == value # no-op
       @updated_keys << key

--- a/lib/airrecord/table.rb
+++ b/lib/airrecord/table.rb
@@ -204,8 +204,11 @@ module Airrecord
 
     def validate_key(key)
       return true unless key.is_a?(Symbol)
-      help = "Try record['#{key.to_s.gsub('_', ' ')}'] instead."
-      raise Error, "Airrecord 1.0 dropped support for Symbols as field names. #{help}"
+      raise Error, <<~MSG
+        Airrecord 1.0 dropped support for Symbols as field names.
+        Please use the full column name, a String, instead.
+        You might try: record['#{key.to_s.gsub('_', ' ')}']
+      MSG
     end
   end
 

--- a/lib/airrecord/table.rb
+++ b/lib/airrecord/table.rb
@@ -109,10 +109,12 @@ module Airrecord
     end
 
     def [](key)
+      validate_key(key)
       fields[key]
     end
 
     def []=(key, value)
+      validate_key(key)
       return if fields[key] == value # no-op
       @updated_keys << key
       fields[key] = value
@@ -198,6 +200,12 @@ module Airrecord
 
     def client
       self.class.client
+    end
+
+    def validate_key(key)
+      return true unless key.is_a?(Symbol)
+      help = "Try record['#{key.to_s.gsub('_', ' ')}'] instead."
+      raise Error, "Airrecord 1.0 dropped support for Symbols as field names. #{help}"
     end
   end
 

--- a/test/table_test.rb
+++ b/test/table_test.rb
@@ -145,6 +145,18 @@ class TableTest < Minitest::Test
     assert record.save
   end
 
+  def test_change_value_with_symbol_raises_error
+    assert_raises Airrecord::Error do
+      first_record[:Name] = "new_name"
+    end
+  end
+
+  def test_access_value_with_symbol_raises_error
+    assert_raises Airrecord::Error do
+      first_record[:Name]
+    end
+  end
+
   def test_updates_fields_to_newest_values_after_update
     record = first_record
 

--- a/test/table_test.rb
+++ b/test/table_test.rb
@@ -148,7 +148,7 @@ class TableTest < Minitest::Test
   def test_updates_fields_to_newest_values_after_update
     record = first_record
 
-    record[:name] = "new_name"
+    record["Name"] = "new_name"
     stub_patch_request(record, ["Name"], return_body: { fields: record.fields.merge("Notes" => "new animal") })
 
     assert record.save

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -28,7 +28,7 @@ class Minitest::Test
     end
   end
 
-  def stub_patch_request(record, updated_keys, table: @table1, status: 200, headers: {}, return_body: nil)
+  def stub_patch_request(record, updated_keys, table: @table, status: 200, headers: {}, return_body: nil)
     return_body ||= { fields: record.fields }
     return_body = return_body.to_json
 


### PR DESCRIPTION
By dropping symbol access, we also get to drop `table#column_mappings` under the hood and simplify `table#[]`.