### PR TITLE
Create new records instead of raising in #save

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,13 +200,22 @@ teas = Tea.find_many(["someid", "anotherid", "yetanotherid"])
 
 ### Creating
 
-Creating a new record is done through `#create`.
+Creating a new record is done through `Table.create`.
 
 ```ruby
-tea = Tea.new("Name" => "Feng Gang", "Type" => "Green", "Country" => "China")
-tea.create # creates the record
+tea = Tea.create("Name" => "Feng Gang", "Type" => "Green", "Country" => "China")
 tea.id # id of the new record
 tea["Name"] # "Feng Gang"
+```
+
+If you need to manipulate a record before saving it, you can use `Table.new`
+instead of `create`, then call `#save` when you're ready.
+
+```ruby
+tea = Tea.new("Type" => "Green", "Country" => "China")
+tea["Name"] = "Feng Gang"
+tea.save
+tea.id
 ```
 
 Note that column names need to match the exact column names in Airtable,

--- a/README.md
+++ b/README.md
@@ -215,7 +215,6 @@ instead of `create`, then call `#save` when you're ready.
 tea = Tea.new("Type" => "Green", "Country" => "China")
 tea["Name"] = "Feng Gang"
 tea.save
-tea.id
 ```
 
 Note that column names need to match the exact column names in Airtable,

--- a/lib/airrecord/table.rb
+++ b/lib/airrecord/table.rb
@@ -72,6 +72,10 @@ module Airrecord
         records(filter: formula).sort_by { |record| or_args.index(record.id) }
       end
 
+      def create(fields)
+        new(fields).tap { |record| record.save }
+      end
+
       def records(filter: nil, sort: nil, view: nil, offset: nil, paginate: true, fields: nil, max_records: nil, page_size: nil)
         options = {}
         options[:filterByFormula] = filter if filter

--- a/lib/airrecord/table.rb
+++ b/lib/airrecord/table.rb
@@ -180,7 +180,7 @@ module Airrecord
     end
 
     def save
-      raise Error, "Unable to save a new record" if new_record?
+      return create if new_record?
 
       return true if @updated_keys.empty?
 

--- a/test/table_test.rb
+++ b/test/table_test.rb
@@ -231,6 +231,26 @@ class TableTest < Minitest::Test
     end
   end
 
+  def test_class_level_create
+    record = @table.new("Name" => "omg")
+
+    stub_post_request(record)
+
+    record = @table.create(record.fields)
+    assert record.id
+  end
+
+  def test_class_level_create_handles_error
+    record = @table.new("Name" => "omg")
+
+    stub_post_request(record, status: 401, return_body: { error: { type: "omg", message: "wow" }})
+
+    assert_raises Airrecord::Error do
+      @table.create record.fields
+    end
+  end
+
+
   def test_find
     record = @table.new("Name" => "walrus")
 

--- a/test/table_test.rb
+++ b/test/table_test.rb
@@ -181,12 +181,12 @@ class TableTest < Minitest::Test
     assert record.save
   end
 
-  def test_update_raises_if_new_record
+  def test_update_creates_if_new_record
     record = @table.new("Name" => "omg")
 
-    assert_raises Airrecord::Error do
-      record.save
-    end
+    stub_post_request(record)
+
+    assert record.save
   end
 
   def test_existing_record_is_not_new


### PR DESCRIPTION
Do you think we should encourage calling `#save` instead of `#create` in the README? Either way, I think we should leave `#create` defined, but I think it might feel simpler to always save records by calling `#save`.

It also might be worth adding a class-level `Table.create` method, which could work similarly to ActiveRecord:

```ruby
Tea.create("Name" => "Darjeeling") #=> <Tea @id="rec123">
```