### PR TITLE
Handle network requests in Airrecord::Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 * When a `has_one` or `belongs_to` association is empty, return `nil` instead of
   a blank record (#51)
 
+* Add tests for Airrecord::Client (#44)
+
 # 1.0.1
 
 * Support JRuby 9.0 and CRuby 2.2 (#47)

--- a/lib/airrecord/client.rb
+++ b/lib/airrecord/client.rb
@@ -32,21 +32,78 @@ module Airrecord
       }
     end
 
+    # TODO: remove in v2
     def escape(*args)
       QueryString.escape(*args)
     end
 
+    # TODO: remove in v2
     def parse(body)
       JSON.parse(body)
     rescue JSON::ParserError
       nil
     end
 
+    # TODO: remove in v2
     def handle_error(status, error)
       if error.is_a?(Hash)
         raise Error, "HTTP #{status}: #{error['error']["type"]}: #{error['error']['message']}"
       else
         raise Error, "HTTP #{status}: Communication error: #{error}"
+      end
+    end
+
+    def request(url, options = {})
+      Request.new(connection, url, options).call
+    end
+
+    class Request
+      DEFAULTS = {
+        method: :get,
+        headers: { 'Content-Type' => 'application/json' },
+      }.freeze
+
+      def initialize(connection, url, options = {})
+        @connection = connection
+        @url = url.split('/').map { |str| QueryString.escape(str) }.join('/')
+        @options = DEFAULTS.merge(options)
+      end
+
+      def call
+        response.success? ? data : handle_error
+      end
+
+      private
+
+      def response
+        @response ||= @connection.run_request(
+          @options[:method].to_sym,
+          @url,
+          @options[:body],
+          @options[:headers],
+          &method(:params)
+        )
+      end
+
+      def params(req)
+        req.params.update(@options[:params]) if @options[:params]
+      end
+
+      def data
+        @data ||= JSON.parse(response.body)
+      rescue JSON::ParserError
+        response.body
+      end
+
+      def handle_error
+        prefix = "HTTP #{response.status}"
+        suffix =
+          if data.is_a?(Hash)
+            "#{data['error']['type']}: #{data['error']['message']}"
+          else
+            "Communication error: #{data}"
+          end
+        raise Error, "#{prefix}: #{suffix}"
       end
     end
   end

--- a/lib/airrecord/table.rb
+++ b/lib/airrecord/table.rb
@@ -120,7 +120,7 @@ module Airrecord
       body = { fields: serializable_fields }.to_json
       parsed_response = client.request(
         "/v0/#{self.class.base_key}/#{self.class.table_name}",
-        method: 'post',
+        method: :post,
         body: body,
       )
       @id = parsed_response["id"]

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -32,6 +32,7 @@ class ClientTest < Minitest::Test
   def test_successful_get_request_returns_valid_json
     @stubs.get('/valid') { |env| [200, {}, { "hello" => "world" }.to_json] }
     response = @client.request('/valid')
+
     assert_equal(response["hello"], "world")
   end
 

--- a/test/client_test.rb
+++ b/test/client_test.rb
@@ -1,0 +1,56 @@
+require 'test_helper'
+
+class ClientTest < Minitest::Test
+  def setup
+    @stubs = Faraday::Adapter::Test::Stubs.new
+    @client = Airrecord::Client.new("API_KEY").tap { |instance|
+      instance.connection = Faraday.new { |builder|
+        builder.adapter :test, @stubs
+      }
+    }
+  end
+
+  def test_client_connection_uses_net_http_persistent_by_default
+    client = Airrecord::Client.new('not stubbed')
+    adapter = client.connection.builder.handlers.last
+
+    assert_equal(adapter, Faraday::Adapter::NetHttpPersistent)
+  end
+
+  def test_client_request_escapes_urls_correctly
+    request = Airrecord::Client::Request.new(
+      'mock client',
+      "/v0/appdnc1gxGiuJIl2U/table name/rec3ksiISOB6cQmtg"
+    )
+
+    expected = "/v0/appdnc1gxGiuJIl2U/table%20name/rec3ksiISOB6cQmtg"
+    actual = request.instance_variable_get(:@url)
+
+    assert_equal expected, actual
+  end
+
+  def test_successful_get_request_returns_valid_json
+    @stubs.get('/valid') { |env| [200, {}, { "hello" => "world" }.to_json] }
+    response = @client.request('/valid')
+    assert_equal(response["hello"], "world")
+  end
+
+  def test_successful_patch_request_returns_valid_json
+    @stubs.patch('/id') { |env| [200, {}, { "hello" => "world" }.to_json] }
+    response = @client.request('/id', method: 'patch')
+
+    assert_equal(response["hello"], "world")
+  end
+
+  def test_successful_request_handles_malformed_json
+    @stubs.delete('/invalid') { |env| [204, {}, ''] }
+
+    assert @client.request('/invalid', method: :delete)
+  end
+
+  def test_unsuccessful_request_raises_error
+    @stubs.get('/error') { |env| [422, {}, "Unprocessable"] }
+
+    assert_raises(Airrecord::Error) { @client.request('/error') }
+  end
+end


### PR DESCRIPTION
Fixes #44.

While I was at it, I thought it would be helpful to draw firmer boundaries between `Table` and `Client`. Specifically, `Table` no longer manipulates network requests directly — it just asks `Client` to make requests, and lets `Client` handle escaping, parsing, errors, etc.

I think this will make it easier to add features to `Table`, like finder methods (#19), validations, etc. But I may have gotten a bit carried away.