### PR TITLE
Do not make network calls for empty has_many associations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 * When a `has_one` or `belongs_to` association is empty, return `nil` instead of
   a blank record (#51)
 
+* When a `has_many` association is empty, do not make a network call to the
+  associated table
+
 # 1.0.1
 
 * Support JRuby 9.0 and CRuby 2.2 (#47)

--- a/lib/airrecord/table.rb
+++ b/lib/airrecord/table.rb
@@ -47,6 +47,8 @@ module Airrecord
       end
 
       def find_many(ids)
+        return [] if ids.empty?
+
         or_args = ids.map { |id| "RECORD_ID() = '#{id}'"}.join(',')
         formula = "OR(#{or_args})"
         records(filter: formula).sort_by { |record| or_args.index(record.id) }

--- a/test/associations_test.rb
+++ b/test/associations_test.rb
@@ -50,7 +50,7 @@ class AssociationsTest < MiniTest::Test
 
   def test_has_many_handles_empty_associations
     tea = Tea.new("Name" => "Gunpowder")
-    stub_request([], table: Brew)
+    stub_request([{ "id" => "brew1", "Name" => "unrelated"  }], table: Brew)
     assert_equal 0, tea.brews.size
   end
 

--- a/test/table_test.rb
+++ b/test/table_test.rb
@@ -286,6 +286,12 @@ class TableTest < Minitest::Test
     assert_instance_of Array, @table.find_many(ids)
   end
 
+  def test_find_many_makes_no_network_call_when_ids_are_empty
+    stub_request([], status: 500)
+
+    assert_equal([], @table.find_many([]))
+  end
+
   def test_destroy_new_record_fails
     record = @table.new("Name" => "walrus")
 


### PR DESCRIPTION
`Table.find_many([])` should not make network calls when its `ids` array is empty. Currently empty ids spawn a request to the table with an empty OR() formula, like this: `/appKey/tableName?filterByFormula=OR()`

That request does return zero records, which is good, but we can speed things up by not making the request in the first place.