### PR TITLE
Support #find_by, #find_by!, #where, #order, and #limit

### DIFF
--- a/lib/airrecord/relation.rb
+++ b/lib/airrecord/relation.rb
@@ -25,8 +25,7 @@ module Airrecord
     end
 
     def each(&block)
-      args = RulesToRecordArgs.call(rules)
-      @table.records(args).each(&block)
+      @table.records(record_params).each(&block)
     end
 
     private
@@ -37,7 +36,7 @@ module Airrecord
     end
 
     # Convert rules to a hash that Table#records can parse, omitting falsy keys
-    RulesToRecordArgs = lambda do |rules|
+    def record_params
       wheres, orders, max = rules.values_at(:where, :order, :limit)
       filters = wheres.map { |key, val| "{#{key}} = '#{val}'" }
       [
@@ -46,6 +45,5 @@ module Airrecord
         [:max_records, max]
       ].select { |_, val| val }.to_h
     end
-    private_constant :RulesToRecordArgs
   end
 end

--- a/lib/airrecord/relation.rb
+++ b/lib/airrecord/relation.rb
@@ -1,0 +1,51 @@
+module Airrecord
+  # Airrecord::Table delegates to a new Airrecord::Relation when you use
+  # ActiveRecord-style query methods like #where, #order, and #limit
+  class Relation
+    include Enumerable
+    attr_reader :rules
+
+    DEFAULT_RULES = { where: {}, order: {} }.freeze
+
+    def initialize(table, rules = {})
+      @table = table
+      @rules = DEFAULT_RULES.merge(rules)
+    end
+
+    def where(conditions = {})
+      new(where: rules[:where].merge(conditions))
+    end
+
+    def limit(count)
+      new(limit: count.to_i)
+    end
+
+    def order(params)
+      new(order: rules[:order].merge(params))
+    end
+
+    def each(&block)
+      args = RulesToRecordArgs.call(rules)
+      @table.records(args).each(&block)
+    end
+
+    private
+
+    # Merge new_rules with @rules in a new relation
+    def new(new_rules)
+      self.class.new(@table, rules.merge(new_rules))
+    end
+
+    # Convert rules to a hash that Table#records can parse, omitting falsy keys
+    RulesToRecordArgs = lambda do |rules|
+      wheres, orders, max = rules.values_at(:where, :order, :limit)
+      filters = wheres.map { |key, val| "{#{key}} = '#{val}'" }
+      [
+        [:filter, filters.any? ? "AND(#{filters.join(', ')})" : nil],
+        [:sort, orders.any? ? orders : nil],
+        [:max_records, max]
+      ].select { |_, val| val }.to_h
+    end
+    private_constant :RulesToRecordArgs
+  end
+end

--- a/lib/airrecord/relation.rb
+++ b/lib/airrecord/relation.rb
@@ -3,17 +3,17 @@ module Airrecord
   # ActiveRecord-style query methods like #where, #order, and #limit
   class Relation
     include Enumerable
-    attr_reader :rules
+    attr_reader :conditions
 
-    DEFAULT_RULES = { where: {}, order: {} }.freeze
+    DEFAULT_CONDITIONS = { where: {}, order: {} }.freeze
 
-    def initialize(table, rules = {})
+    def initialize(table, conditions = {})
       @table = table
-      @rules = DEFAULT_RULES.merge(rules)
+      @conditions = DEFAULT_CONDITIONS.merge(conditions)
     end
 
-    def where(conditions = {})
-      new(where: rules[:where].merge(conditions))
+    def where(params = {})
+      new(where: conditions[:where].merge(params))
     end
 
     def limit(count)
@@ -21,7 +21,7 @@ module Airrecord
     end
 
     def order(params)
-      new(order: rules[:order].merge(params))
+      new(order: conditions[:order].merge(params))
     end
 
     def each(&block)
@@ -30,14 +30,14 @@ module Airrecord
 
     private
 
-    # Merge new_rules with @rules in a new relation
-    def new(new_rules)
-      self.class.new(@table, rules.merge(new_rules))
+    # Merge more_conditions with @conditions in a new Relation
+    def new(more_conditions)
+      self.class.new(@table, conditions.merge(more_conditions))
     end
 
-    # Convert rules to a hash that Table#records can parse, omitting falsy keys
+    # Convert conditions to a hash that Table#records can parse, omitting falsy keys
     def record_params
-      wheres, orders, max = rules.values_at(:where, :order, :limit)
+      wheres, orders, max = conditions.values_at(:where, :order, :limit)
       filters = wheres.map { |key, val| "{#{key}} = '#{val}'" }
       [
         [:filter, filters.any? ? "AND(#{filters.join(', ')})" : nil],

--- a/lib/airrecord/table.rb
+++ b/lib/airrecord/table.rb
@@ -57,6 +57,19 @@ module Airrecord
         records(filter: formula).sort_by { |record| or_args.index(record.id) }
       end
 
+      def find_by(conditions)
+        where(conditions).first
+      end
+
+      def find_by!(conditions)
+        find_by(conditions) || client.handle_error(404, {
+          "error" => {
+            "type" => "RECORD_NOT_FOUND",
+            "message" => "No record matches those conditions"
+          }
+        })
+      end
+
       def create(fields)
         new(fields).tap { |record| record.save }
       end

--- a/lib/airrecord/table.rb
+++ b/lib/airrecord/table.rb
@@ -122,7 +122,7 @@ module Airrecord
 
       # Delegate chainable query methods to Airrecord::Relation
       extend Forwardable
-      def relation() Airrecord::Relation.new(self) end
+      define_method(:relation) { Airrecord::Relation.new(self) }
       def_delegators :relation, :where, :limit, :order
     end
 

--- a/lib/airrecord/table.rb
+++ b/lib/airrecord/table.rb
@@ -1,3 +1,6 @@
+require 'forwardable'
+require_relative 'relation'
+
 module Airrecord
   class Table
     class << self
@@ -103,6 +106,11 @@ module Airrecord
         end
       end
       alias_method :all, :records
+
+      # Delegate chainable query methods to Airrecord::Relation
+      extend Forwardable
+      def relation() Airrecord::Relation.new(self) end
+      def_delegators :relation, :where, :limit, :order
     end
 
     attr_reader :fields, :id, :created_at, :updated_keys

--- a/test/relation_test.rb
+++ b/test/relation_test.rb
@@ -32,18 +32,18 @@ class RelationTest < MiniTest::Test
   end
 
   def test_order_converts_to_sort_param
-    expected = { sort: { 'Name' => 'Desc' } }
-    actual = @table.order('Name' => 'Desc').to_h
+    expected = { sort: { 'Name' => 'desc' } }
+    actual = @table.order('Name' => 'desc').to_h
 
     assert_equal expected, actual
   end
 
   def test_order_merges_multiple_calls
-    expected = { sort: { 'Name' => 'Desc', 'Rank' => 'Asc' } }
+    expected = { sort: { 'Name' => 'desc', 'Rank' => 'asc' } }
     actual = @table
-      .order('Name' => 'Asc')
-      .order('Name' => 'Desc')
-      .order('Rank' => 'Asc')
+      .order('Name' => 'asc')
+      .order('Name' => 'desc')
+      .order('Rank' => 'asc')
       .to_h
 
     assert_equal expected, actual

--- a/test/relation_test.rb
+++ b/test/relation_test.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 class RelationTest < MiniTest::Test
   def setup
     @table = Airrecord.table("key1", "app1", "table1")
+    # stub Table.records to return options instead of making a network call
     @table.define_singleton_method(:records) { |options| options }
   end
 

--- a/test/relation_test.rb
+++ b/test/relation_test.rb
@@ -2,65 +2,60 @@ require 'test_helper'
 
 class RelationTest < MiniTest::Test
   def setup
-    Airrecord::Relation.define_method(:inspect) do
-      self.class.const_get(:RulesToRecordArgs).call rules
-    end
-    @relation = Airrecord::Relation.new('mock table')
+    @table = Airrecord.table("key1", "app1", "table1")
+    @table.define_singleton_method(:records) { |options| options }
   end
 
   def test_blank_relation_produces_empty_params
-    assert_equal({}, @relation.where.inspect)
+    assert_equal({}, @table.where.to_h)
   end
 
   def test_where_with_one_key_makes_valid_filter
     expected = { filter: "AND({Rank} = 'Captain')" }
-    actual = @relation.where("Rank" => "Captain").inspect
+    actual = @table.where("Rank" => "Captain").to_h
 
     assert_equal expected, actual
   end
 
   def test_where_with_many_keys_makes_valid_filter
     expected = { filter: "AND({Rank} = 'Captain', {Name} = 'Spock')" }
-    actual = @relation.where("Rank" => "Captain", "Name" => "Spock").inspect
+    actual = @table.where("Rank" => "Captain", "Name" => "Spock").to_h
 
     assert_equal expected, actual
   end
 
   def test_where_merges_multiple_calls_into_valid_filter
     expected = { filter: "AND({Rank} = 'Captain', {Name} = 'Spock')" }
-    actual = @relation
-      .where("Rank" => "Captain")
-      .where("Name" => "Spock")
-      .inspect
+    actual = @table.where("Rank" => "Captain").where("Name" => "Spock").to_h
 
     assert_equal expected, actual
   end
 
   def test_order_converts_to_sort_param
     expected = { sort: { 'Name' => 'Desc' } }
-    actual = @relation.order('Name' => 'Desc').inspect
+    actual = @table.order('Name' => 'Desc').to_h
 
     assert_equal expected, actual
   end
 
   def test_order_merges_multiple_calls
     expected = { sort: { 'Name' => 'Desc', 'Rank' => 'Asc' } }
-    actual = @relation
+    actual = @table
       .order('Name' => 'Asc')
       .order('Name' => 'Desc')
       .order('Rank' => 'Asc')
-      .inspect
+      .to_h
 
     assert_equal expected, actual
   end
 
   def test_limit_produces_max_records_param
-    assert_equal({ max_records: 1 }, @relation.limit(1).inspect)
+    assert_equal({ max_records: 1 }, @table.limit(1).to_h)
   end
 
   def test_limit_overwrites_multiple_calls
     expected = { max_records: 10 }
-    actual = @relation.limit(1).limit(3).limit(10).inspect
+    actual = @table.limit(1).limit(3).limit(10).to_h
 
     assert_equal expected, actual
   end
@@ -72,11 +67,11 @@ class RelationTest < MiniTest::Test
       max_records: 10,
     }
 
-    actual = @relation
+    actual = @table
       .where('Name' => 'McCoy', 'Rank' => 'Commander')
       .order('Name' => 'Asc')
       .limit(10)
-      .inspect
+      .to_h
 
     assert_equal expected, actual
   end

--- a/test/relation_test.rb
+++ b/test/relation_test.rb
@@ -1,0 +1,83 @@
+require 'test_helper'
+
+class RelationTest < MiniTest::Test
+  def setup
+    Airrecord::Relation.define_method(:inspect) do
+      self.class.const_get(:RulesToRecordArgs).call rules
+    end
+    @relation = Airrecord::Relation.new('mock table')
+  end
+
+  def test_blank_relation_produces_empty_params
+    assert_equal({}, @relation.where.inspect)
+  end
+
+  def test_where_with_one_key_makes_valid_filter
+    expected = { filter: "AND({Rank} = 'Captain')" }
+    actual = @relation.where("Rank" => "Captain").inspect
+
+    assert_equal expected, actual
+  end
+
+  def test_where_with_many_keys_makes_valid_filter
+    expected = { filter: "AND({Rank} = 'Captain', {Name} = 'Spock')" }
+    actual = @relation.where("Rank" => "Captain", "Name" => "Spock").inspect
+
+    assert_equal expected, actual
+  end
+
+  def test_where_merges_multiple_calls_into_valid_filter
+    expected = { filter: "AND({Rank} = 'Captain', {Name} = 'Spock')" }
+    actual = @relation
+      .where("Rank" => "Captain")
+      .where("Name" => "Spock")
+      .inspect
+
+    assert_equal expected, actual
+  end
+
+  def test_order_converts_to_sort_param
+    expected = { sort: { 'Name' => 'Desc' } }
+    actual = @relation.order('Name' => 'Desc').inspect
+
+    assert_equal expected, actual
+  end
+
+  def test_order_merges_multiple_calls
+    expected = { sort: { 'Name' => 'Desc', 'Rank' => 'Asc' } }
+    actual = @relation
+      .order('Name' => 'Asc')
+      .order('Name' => 'Desc')
+      .order('Rank' => 'Asc')
+      .inspect
+
+    assert_equal expected, actual
+  end
+
+  def test_limit_produces_max_records_param
+    assert_equal({ max_records: 1 }, @relation.limit(1).inspect)
+  end
+
+  def test_limit_overwrites_multiple_calls
+    expected = { max_records: 10 }
+    actual = @relation.limit(1).limit(3).limit(10).inspect
+
+    assert_equal expected, actual
+  end
+
+  def test_chaining_multiple_methods_produces_valid_params
+    expected = {
+      filter: "AND({Name} = 'McCoy', {Rank} = 'Commander')",
+      sort: { 'Name' => 'Asc' },
+      max_records: 10,
+    }
+
+    actual = @relation
+      .where('Name' => 'McCoy', 'Rank' => 'Commander')
+      .order('Name' => 'Asc')
+      .limit(10)
+      .inspect
+
+    assert_equal expected, actual
+  end
+end

--- a/test/table_test.rb
+++ b/test/table_test.rb
@@ -88,6 +88,17 @@ class TableTest < Minitest::Test
     assert_equal 2, records.size
   end
 
+  def test_chaining_relation_methods_returns_enumerable_relation
+    stub_request([ { 'Name' => 'Kirk', 'Rank' => 'Captain' } ])
+    relation = @table
+      .where('Rank' => 'Captain')
+      .order('Name' => 'Asc')
+      .limit(1)
+
+    assert relation.class.included_modules.include?(Enumerable)
+    assert_equal(['Kirk'], relation.map { |record| record['Name'] })
+  end
+
   def test_index_by_normalized_name
     assert_equal "omg", first_record["Name"]
   end

--- a/test/table_test.rb
+++ b/test/table_test.rb
@@ -90,7 +90,7 @@ class TableTest < Minitest::Test
 
   def test_chaining_relation_methods_returns_enumerable_relation
     stub_request([ { 'Name' => 'Kirk', 'Rank' => 'Captain' } ])
-    relation = @table.where('Rank' => 'Captain').order('Name' => 'Asc').limit(1)
+    relation = @table.where('Rank' => 'Captain').order('Name' => 'asc').limit(1)
 
     assert relation.class.included_modules.include?(Enumerable)
     assert_equal(['Kirk'], relation.map { |record| record['Name'] })
@@ -298,6 +298,27 @@ class TableTest < Minitest::Test
     stub_request([], status: 500)
 
     assert_equal([], @table.find_many([]))
+  end
+
+  def test_find_by_returns_one_record
+    stub_request([{ 'Name' => 'walrus' }])
+
+    assert_equal 'walrus', @table.find_by('Name' => 'walrus')['Name']
+    assert_equal 'walrus', @table.find_by!('Name' => 'walrus')['Name']
+  end
+
+  def test_find_by_returns_nil_when_no_record_matches
+    stub_request([])
+
+    assert_nil @table.find_by('Name' => 'walrus')
+  end
+
+  def test_find_by_raises_404_when_no_record_matches_and_called_with_bang
+    stub_request([])
+
+    assert_raises Airrecord::Error do
+      @table.find_by!('Name' => 'walrus')
+    end
   end
 
   def test_destroy_new_record_fails

--- a/test/table_test.rb
+++ b/test/table_test.rb
@@ -90,10 +90,7 @@ class TableTest < Minitest::Test
 
   def test_chaining_relation_methods_returns_enumerable_relation
     stub_request([ { 'Name' => 'Kirk', 'Rank' => 'Captain' } ])
-    relation = @table
-      .where('Rank' => 'Captain')
-      .order('Name' => 'Asc')
-      .limit(1)
+    relation = @table.where('Rank' => 'Captain').order('Name' => 'Asc').limit(1)
 
     assert relation.class.included_modules.include?(Enumerable)
     assert_equal(['Kirk'], relation.map { |record| record['Name'] })


### PR DESCRIPTION
This PR closes #19 and makes the following behavior possible:

```ruby
Tea.where("Type" => "Green").where("Price" => 10).order("Name" => "asc").limit(1)
Tea.find_by("Name" => "Rooibos Vanilla")
```

I still need to update the README and changelog, but wanted to make sure this approach looks okay to you, @sirupsen. I'm happy with it so far, but have some questions:

- Should `#where` accept raw Airtable formula components, in addition to the conditions hash it currently accepts? Like `Tea.where("Type => "Green").where("{Price} < 30")`?
- To support chaining, `#where`, `#order`, and `#limit` all return an instance of Airrecord::Relation, an Enumerable that only calls `Table#records` after you try do something with it, like `each`, `map`, `to_a`, etc. In 2.0, should the `has_many` API also return a Relation instead of an Array, so you could call `Tea.find(id).brews.where("Temperature" => 90)`?
- I didn't see anything in the ActiveRecord code that looked like it would make query chaining easier than a plain Ruby class, but I definitely don't want to write callbacks or validations from scratch! What do you think of https://www.rubydoc.info/github/apotonick/hooks for callbacks, and maybe https://github.com/dry-rb/dry-validation for validations? For the sake of the Ruby devs who write web apps without ActiveRecord (all twelve of us), I'm reluctant to add a dependency as large as ActiveRecord. Maybe that's naive of me 🤷‍♂️ 
- I updated these [tests against a live Airtable base](https://github.com/chrisfrank/airrecord-integration) to cover the Relation methods. What do you think about adding a few live tests to the Airrecord repo, behind an optional ENV flag or something? I'd like to able to test against a live repo before every release.