### PR TITLE
Relax net-http-persistent dependency to allow latest

### DIFF
--- a/airrecord.gemspec
+++ b/airrecord.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.2'
 
   spec.add_dependency 'faraday', '~> 0.10'
-  spec.add_dependency "net-http-persistent", '~> 2.9'
+  spec.add_dependency "net-http-persistent", '>= 2.9'
 
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
See also: https://github.com/drbrain/net-http-persistent/blob/master/History.txt

Didn't see any issues that would arise from breaking changes, tests pass, etc. Notably, Stripe 4.x.x gemspec requires 3.0+.