### PR TITLE
Fix net-http-persistent gem version

### DIFF
--- a/airrecord.gemspec
+++ b/airrecord.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.2'
 
   spec.add_dependency 'faraday', '~> 0.10'
-  spec.add_dependency "net-http-persistent", '>= 2.9'
+  spec.add_dependency "net-http-persistent", '~> 2.9'
 
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "rake", "~> 10.0"


### PR DESCRIPTION
Issue: https://github.com/sirupsen/airrecord/issues/63

I'm having some issues with Airrecord when trying to manage records after some debugging I found that:

> Unfortunately it looks like net-http-persisten introduced some breaking changes in its 3.0.0 release, making Faraday incompatible.

Related: https://github.com/lostisland/faraday/issues/617

## Fixing

Set an older version for `net-http-persistent` gem.