### PR TITLE
Add support for optional request params in save and create

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,13 +229,13 @@ This is also supported when updating existing records with the `#save` method.
 ```ruby
 tea = Tea.create(
   {"Name" => "Feng Gang", "Type" => "Green", "Country" => "China"},
-  request_options: {"typecast" => true},
+  {"typecast" => true},
 )
 
 # Or with the #save method:
 tea = Tea.new({"Name" => "Feng Gang", "Type" => "Green"})
 tea["Name"] = "Feng Gang"
-tea.save(request_options: {"typecast" => true})
+tea.save("typecast" => true)
 ```
 
 _Earlier versions of airrecord provided methods for snake-cased column names

--- a/README.md
+++ b/README.md
@@ -222,6 +222,22 @@ tea.save
 Note that column names need to match the exact column names in Airtable,
 otherwise Airrecord will throw an error that no column matches it.
 
+
+If you need to include optional request parameters, such as the `typecast` parameter, these can be passed to either `Table.create` or `#save`.
+This is also supported when updating existing records with the `#save` method.
+
+```ruby
+tea = Tea.create(
+  {"Name" => "Feng Gang", "Type" => "Green", "Country" => "China"},
+  request_options: {"typecast" => true},
+)
+
+# Or with the #save method:
+tea = Tea.new({"Name" => "Feng Gang", "Type" => "Green"})
+tea["Name"] = "Feng Gang"
+tea.save(request_options: {"typecast" => true})
+```
+
 _Earlier versions of airrecord provided methods for snake-cased column names
 and symbols, however this proved error-prone without a proper schema API from
 Airtable which has still not been released._

--- a/airrecord.gemspec
+++ b/airrecord.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday', '~> 0.10'
   spec.add_dependency "net-http-persistent", '>= 2.9'
 
-  spec.add_development_dependency "bundler", "~> 1.12"
+  spec.add_development_dependency "bundler", "~> 2.1.2"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "byebug"

--- a/lib/airrecord/table.rb
+++ b/lib/airrecord/table.rb
@@ -54,8 +54,8 @@ module Airrecord
         records(filter: formula).sort_by { |record| or_args.index(record.id) }
       end
 
-      def create(fields, request_options: {})
-        new(fields).tap { |record| record.save(request_options: request_options) }
+      def create(fields, options={})
+        new(fields).tap { |record| record.save(options) }
       end
 
       def records(filter: nil, sort: nil, view: nil, offset: nil, paginate: true, fields: nil, max_records: nil, page_size: nil)
@@ -129,12 +129,12 @@ module Airrecord
       fields[key] = value
     end
 
-    def create(request_options: {})
+    def create(options={})
       raise Error, "Record already exists (record has an id)" unless new_record?
 
       body = {
         fields: serializable_fields,
-        **request_options,
+        **options,
       }.to_json
 
       response = client.connection.post("/v0/#{self.class.base_key}/#{client.escape(self.class.table_name)}", body, { 'Content-Type' => 'application/json' })
@@ -149,8 +149,8 @@ module Airrecord
       end
     end
 
-    def save(request_options: {})
-      return create(request_options: request_options) if new_record?
+    def save(options={})
+      return create(options) if new_record?
 
       return true if @updated_keys.empty?
 
@@ -159,7 +159,7 @@ module Airrecord
         fields: Hash[@updated_keys.map { |key|
           [key, fields[key]]
         }],
-        **request_options,
+        **options,
       }.to_json
 
       response = client.connection.patch("/v0/#{self.class.base_key}/#{client.escape(self.class.table_name)}/#{self.id}", body, { 'Content-Type' => 'application/json' })

--- a/lib/airrecord/table.rb
+++ b/lib/airrecord/table.rb
@@ -54,8 +54,8 @@ module Airrecord
         records(filter: formula).sort_by { |record| or_args.index(record.id) }
       end
 
-      def create(fields)
-        new(fields).tap { |record| record.save }
+      def create(fields, request_options: {})
+        new(fields).tap { |record| record.save(request_options: request_options) }
       end
 
       def records(filter: nil, sort: nil, view: nil, offset: nil, paginate: true, fields: nil, max_records: nil, page_size: nil)
@@ -129,10 +129,14 @@ module Airrecord
       fields[key] = value
     end
 
-    def create
+    def create(request_options: {})
       raise Error, "Record already exists (record has an id)" unless new_record?
 
-      body = { fields: serializable_fields }.to_json
+      body = {
+        fields: serializable_fields,
+        **request_options,
+      }.to_json
+
       response = client.connection.post("/v0/#{self.class.base_key}/#{client.escape(self.class.table_name)}", body, { 'Content-Type' => 'application/json' })
       parsed_response = client.parse(response.body)
 
@@ -145,8 +149,8 @@ module Airrecord
       end
     end
 
-    def save
-      return create if new_record?
+    def save(request_options: {})
+      return create(request_options: request_options) if new_record?
 
       return true if @updated_keys.empty?
 
@@ -154,7 +158,8 @@ module Airrecord
       body = {
         fields: Hash[@updated_keys.map { |key|
           [key, fields[key]]
-        }]
+        }],
+        **request_options,
       }.to_json
 
       response = client.connection.patch("/v0/#{self.class.base_key}/#{client.escape(self.class.table_name)}/#{self.id}", body, { 'Content-Type' => 'application/json' })

--- a/test/table_test.rb
+++ b/test/table_test.rb
@@ -135,13 +135,13 @@ class TableTest < Minitest::Test
     assert record.save
   end
 
-  def test_change_value_and_update_with_options
+  def test_change_value_and_update_with_typecast_enabled
     record = first_record
 
     record["Name"] = "new_name"
-    stub_patch_request(record, ["Name"], request_options: {typecase: true})
+    stub_patch_request(record, ["Name"], options: {typecast: true})
 
-    assert record.save(request_options: {typecase: true})
+    assert record.save(typecast: true)
   end
 
   def test_change_value_then_save_again_should_noop
@@ -230,12 +230,12 @@ class TableTest < Minitest::Test
     assert record.create
   end
 
-  def test_create_new_record_with_options
+  def test_create_new_record_with_typecast_enabled
     record = @table.new("Name" => "omg")
 
-    stub_post_request(record, request_options: {typecase: true})
+    stub_post_request(record, options: {typecast: true})
 
-    assert record.create(request_options: {typecase: true})
+    assert record.create(typecast: true)
   end
 
   def test_create_existing_record_fails
@@ -269,12 +269,12 @@ class TableTest < Minitest::Test
     assert record.id
   end
 
-  def test_class_level_create_with_options
+  def test_class_level_create_with_typecast_enabled
     record = @table.new("Name" => "omg")
 
-    stub_post_request(record, request_options: {typecase: true})
+    stub_post_request(record, options: {typecast: true})
 
-    record = @table.create(record.fields, request_options: {typecase: true})
+    record = @table.create(record.fields, typecast: true)
     assert record.id
   end
 

--- a/test/table_test.rb
+++ b/test/table_test.rb
@@ -135,6 +135,15 @@ class TableTest < Minitest::Test
     assert record.save
   end
 
+  def test_change_value_and_update_with_options
+    record = first_record
+
+    record["Name"] = "new_name"
+    stub_patch_request(record, ["Name"], request_options: {typecase: true})
+
+    assert record.save(request_options: {typecase: true})
+  end
+
   def test_change_value_then_save_again_should_noop
     record = first_record
 
@@ -221,6 +230,14 @@ class TableTest < Minitest::Test
     assert record.create
   end
 
+  def test_create_new_record_with_options
+    record = @table.new("Name" => "omg")
+
+    stub_post_request(record, request_options: {typecase: true})
+
+    assert record.create(request_options: {typecase: true})
+  end
+
   def test_create_existing_record_fails
     record = @table.new("Name" => "omg")
 
@@ -249,6 +266,15 @@ class TableTest < Minitest::Test
     stub_post_request(record)
 
     record = @table.create(record.fields)
+    assert record.id
+  end
+
+  def test_class_level_create_with_options
+    record = @table.new("Name" => "omg")
+
+    stub_post_request(record, request_options: {typecase: true})
+
+    record = @table.create(record.fields, request_options: {typecase: true})
     assert record.id
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,7 +11,7 @@ class Minitest::Test
     end
   end
 
-  def stub_post_request(record, table: @table, status: 200, headers: {}, request_options: {}, return_body: nil)
+  def stub_post_request(record, table: @table, status: 200, headers: {}, options: {}, return_body: nil)
     return_body ||= {
       id: SecureRandom.hex(16),
       fields: record.serializable_fields,
@@ -21,7 +21,7 @@ class Minitest::Test
 
     request_body = {
       fields: record.serializable_fields,
-      **request_options,
+      **options,
     }.to_json
 
     @stubs.post("/v0/#{table.base_key}/#{table.table_name}", request_body) do |env|
@@ -29,7 +29,7 @@ class Minitest::Test
     end
   end
 
-  def stub_patch_request(record, updated_keys, table: @table, status: 200, headers: {}, request_options: {}, return_body: nil)
+  def stub_patch_request(record, updated_keys, table: @table, status: 200, headers: {}, options: {}, return_body: nil)
     return_body ||= { fields: record.fields }
     return_body = return_body.to_json
 
@@ -37,7 +37,7 @@ class Minitest::Test
       fields: Hash[updated_keys.map { |key|
         [key, record.fields[key]]
       }],
-      **request_options,
+      **options,
     }.to_json
     @stubs.patch("/v0/#{@table.base_key}/#{@table.table_name}/#{record.id}", request_body) do |env|
       [status, headers, return_body]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,7 +11,7 @@ class Minitest::Test
     end
   end
 
-  def stub_post_request(record, table: @table, status: 200, headers: {}, return_body: nil)
+  def stub_post_request(record, table: @table, status: 200, headers: {}, request_options: {}, return_body: nil)
     return_body ||= {
       id: SecureRandom.hex(16),
       fields: record.serializable_fields,
@@ -21,6 +21,7 @@ class Minitest::Test
 
     request_body = {
       fields: record.serializable_fields,
+      **request_options,
     }.to_json
 
     @stubs.post("/v0/#{table.base_key}/#{table.table_name}", request_body) do |env|
@@ -28,14 +29,15 @@ class Minitest::Test
     end
   end
 
-  def stub_patch_request(record, updated_keys, table: @table, status: 200, headers: {}, return_body: nil)
+  def stub_patch_request(record, updated_keys, table: @table, status: 200, headers: {}, request_options: {}, return_body: nil)
     return_body ||= { fields: record.fields }
     return_body = return_body.to_json
 
     request_body = {
       fields: Hash[updated_keys.map { |key|
         [key, record.fields[key]]
-      }]
+      }],
+      **request_options,
     }.to_json
     @stubs.patch("/v0/#{@table.base_key}/#{@table.table_name}/#{record.id}", request_body) do |env|
       [status, headers, return_body]


### PR DESCRIPTION
The `typecast: true` parameter is needed in API requests to enable automatic data conversion from string values. This PR extends the `create` and `save` methods to support optional parameters in the request so that typecasting can be enabled. I chose to do this with a generic options hash instead of a specific `typecast` flag so that future changes to the API, such as new parameters, will be supported without requiring changes to the gem.

This change should have no impact on current users since it is an optional argument for both methods.

Fixes https://github.com/sirupsen/airrecord/issues/13