### PR TITLE
Merge pull request #68 from rcscott/find-created-at

### DIFF
--- a/lib/airrecord/table.rb
+++ b/lib/airrecord/table.rb
@@ -40,7 +40,7 @@ module Airrecord
         parsed_response = client.parse(response.body)
 
         if response.success?
-          self.new(parsed_response["fields"], id: id)
+          self.new(parsed_response["fields"], id: id, created_at: parsed_response["createdTime"])
         else
           client.handle_error(response.status, parsed_response)
         end

--- a/test/table_test.rb
+++ b/test/table_test.rb
@@ -297,6 +297,7 @@ class TableTest < Minitest::Test
     record = @table.find("iodfajsofja")
     assert_equal "walrus", record["Name"]
     assert_equal "iodfajsofja", record.id
+    assert_instance_of Time, record.created_at
   end
 
   def test_find_handles_error

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -68,6 +68,7 @@ class Minitest::Test
     return_body ||= {
       id: id,
       fields: record.fields,
+      createdTime: Time.now,
     }
     return_body = return_body.to_json
 


### PR DESCRIPTION
The gem parses the `createdTime` value from responses when records are created and when retrieving a list of records, but it doesn't currently do this when retrieving a single record. This pull request updates the `find` method to parse this value and add it to the object's `created_at` attribute like the other methods do.

Examples of how this is done on the other methods:

https://github.com/sirupsen/airrecord/blob/9d6426f71e3d32ef74ef0ab143601f707d60406a/lib/airrecord/table.rb#L145

https://github.com/sirupsen/airrecord/blob/9d6426f71e3d32ef74ef0ab143601f707d60406a/lib/airrecord/table.rb#L84