### PR TITLE
Allow using Faraday 1.x release in gemspec

### DIFF
--- a/airrecord.gemspec
+++ b/airrecord.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = '>= 2.2'
 
-  spec.add_dependency 'faraday', '~> 0.10'
+  spec.add_dependency 'faraday', ['>= 0.10', '< 2.0']
   spec.add_dependency "net-http-persistent", '>= 2.9'
 
   spec.add_development_dependency "bundler", "~> 2.1.2"


### PR DESCRIPTION
[Faraday has released a 1.0 version](https://github.com/lostisland/faraday/blob/master/CHANGELOG.md#v10) last month, but `airrecord` depends on the `0.x` series of Faraday versions by gemspec.  

Let's allow using the latest version of Faraday but avoid a major upgrade to `2.x` by maintaining a version constraint.