### PR TITLE
Table.batch_update

### DIFF
--- a/test/table_test.rb
+++ b/test/table_test.rb
@@ -120,6 +120,33 @@ class TableTest < Minitest::Test
     assert_equal "testest", record["Name"]
   end
 
+  def test_updated_fields
+    record = first_record
+    record["Name"] = "testest"
+    assert_equal "testest", record.updated_fields["Name"]
+    # Make sure "Notes" field isn't in updated_fields, it hasn't been updated
+    assert_nil record.updated_fields["Notes"]
+  end
+
+  def test_to_h
+    record = first_record
+
+    h = record.to_h
+    assert h[:id].is_a? String
+    assert_equal h[:fields]["Name"], "omg"
+  end
+
+  def test_to_h_only_updated_fields
+    record = first_record
+    record["Name"] = "testest"
+
+    h = record.to_h(true)
+    assert h[:id].is_a? String
+    assert_equal h[:fields]["Name"], "testest"
+    # Make sure "Notes" field isn't in updated_fields, it hasn't been updated
+    assert_nil h[:fields]["Notes"]
+  end
+
   def test_change_value_on_column_name
     record = first_record
     record["Name"] = "testest"
@@ -208,6 +235,31 @@ class TableTest < Minitest::Test
     stub_post_request(record)
 
     assert record.save
+  end
+
+  def test_batch_update_fails_unless_array
+    record = @table.new("Name" => "omg")
+    assert_raises Airrecord::Error do
+      @table.batch_update(record)
+    end
+  end
+
+  def test_batch_update_fails_if_exceeds_batch_limit
+    @table.batch_limit = 2
+    record1 = @table.new("Name" => "omg1")
+    record2 = @table.new("Name" => "omg2")
+    record3 = @table.new("Name" => "omg3")
+    assert_raises Airrecord::Error do
+      @table.batch_update([record1, record2, record3])
+    end
+  end
+
+
+  def test_batch_update_fails_if_new_record
+    record = @table.new("Name" => "omg")
+    assert_raises Airrecord::Error do
+      @table.batch_update([record])
+    end
   end
 
   def test_existing_record_is_not_new
@@ -377,7 +429,7 @@ class TableTest < Minitest::Test
     walrus = Walrus.new("Name" => "Wally")
     foot = Foot.new("Name" => "FrontRight", "walrus" => walrus)
 
-    foot.serializable_fields
+    foot.fields
   end
 
   def test_dont_update_if_equal
@@ -398,19 +450,5 @@ class TableTest < Minitest::Test
     walrus2 = Walrus.new("Name" => "Wally2")
 
     assert !walrus1.eql?(walrus2)
-  end
-
-  def test_equivalent_hash_equality
-    walrus1 = Walrus.new("Name" => "Wally")
-    walrus2 = Walrus.new("Name" => "Wally")
-
-    assert_equal walrus1.hash, walrus2.hash
-  end
-
-  def test_non_equivalent_hash_inequality
-    walrus1 = Walrus.new("Name" => "Wally")
-    walrus2 = Walrus.new("Name" => "Wally2")
-
-    assert walrus1.hash != walrus2.hash
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,13 +14,13 @@ class Minitest::Test
   def stub_post_request(record, table: @table, status: 200, headers: {}, options: {}, return_body: nil)
     return_body ||= {
       id: SecureRandom.hex(16),
-      fields: record.serializable_fields,
+      fields: record.fields,
       createdTime: Time.now,
     }
     return_body = return_body.to_json
 
     request_body = {
-      fields: record.serializable_fields,
+      fields: record.fields,
       **options,
     }.to_json
 
@@ -40,6 +40,23 @@ class Minitest::Test
       **options,
     }.to_json
     @stubs.patch("/v0/#{@table.base_key}/#{@table.table_name}/#{record.id}", request_body) do |env|
+      [status, headers, return_body]
+    end
+  end
+
+  def stub_update_batch_request(records, table: @table, status: 200, headers: {}, options: {}, return_body: nil)
+    unless return_body
+      return_body_records = records.map { |record| record.to_h(true) }
+      return_body = { records: return_body_records }
+    end
+    return_body = return_body.to_json
+
+    request_body_records = records.map { |record| record.to_h(true) }
+    request_body = {
+      records: request_body_records,
+      **options,
+    }.to_json
+    @stubs.patch("/v0/#{@table.base_key}/#{@table.table_name}", request_body) do |env|
       [status, headers, return_body]
     end
   end


### PR DESCRIPTION
This is not ready for merging, but I wanted to submit a proof of concept for https://github.com/sirupsen/airrecord/issues/66 in case somebody else wants to run with it.

This enables an API for Table.batch_update that can take up to 10 existing records (they must already exist in Airtable) and bulk update them with a single API request, as Airtable's API now allows batches of 10 for created, updates, and deletes.

Still needs:
* Better testing of the Table.batch_update function, but I've seen it working in a project.

Example usage
```rb
ben = Seat.find("recMxPcmAqeo7iGj7")
ben["Fun Fact"] = Faker::Music::UmphreysMcgee.song
Seat.batch_update([ben])
```

Other notes and potential breaking changes:
* Removes `record.hash`, I didn't see it being used for anything aside from a test making sure it worked.
* Removes `record.serializable_fields`, I didn't see it being used for anything aside from tests, use `record.fields` instead.
* Adds `record.to_h` which gives the record format used in batch operations (i.e. includes `id` and `fields`)
* Adds `record.to_h(true)` which gives the record format used in batch operations (i.e. includes `id` and `fields`), but ONLY includes the updated fields. This can be used for PATCH updates.

Ideal design for this:
* Airtable now supports batches of 10 for gets, creates, and updates, and deletes. It would be awesome to have a Table.batch_upsert method that accepts up to 10 records, does a multi-get for the 10 records, figures out which ones already exist and don't exist, then runs Test.batch_create for the records that don't exist and Test.batch_update for the records that do exist. Then you could batch import records by just blasting them into Table.batch_upsert.