### PR TITLE
Add info about updating attachment's filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,8 @@ tea["Village"] = "Feng Gang"
 tea.save # persist to Airtable
 ```
 
+_Airtable's API doesn't allow you to change attachment's filename. As a workaround you can delete the original attachment and [upload a new one](https://github.com/sirupsen/airrecord#file-uploads) with the original URL and a new filename._
+
 ### Deleting
 
 An instantiated record can be deleted through `#destroy`:

--- a/airrecord.gemspec
+++ b/airrecord.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'faraday', ['>= 0.10', '< 2.0']
   spec.add_dependency "net-http-persistent", '>= 2.9'
 
-  spec.add_development_dependency "bundler", "~> 2.1.2"
+  spec.add_development_dependency "bundler", "~> 2"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "byebug"


### PR DESCRIPTION
Fixes #77

There was an issue while changing the attachment's filename on a record without success, failing silently. And no details on that in this Airrecord or Airtable API. In the end, it was an issue of Airtable. Updated the Readme to help others.

@Meekohi @rcscott in the end, I documented in under https://github.com/sirupsen/airrecord#updating instead of https://github.com/sirupsen/airrecord#file-uploads. 