### PR TITLE
Table#batch_create

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,38 @@ end
 Tea.find("rec3838")
 ```
 
+#### Creating in Batch
+It's possible to create multiples records using an anonymous `Airrecord::Table`. 
+
+The `#batch_create` receives an array of hashes, you can define the size of the batch passing the parameters `batch_limit: XX`, the maximum number of records permitted per request by AirTable is 10, and it's the gem's default as well.
+
+To avoid request problems, the maximum number of "chunks" permitted is 5. In other words, if you use the `batch_limit: 10`, you can pass an array having 50 elements.
+
+```ruby
+Tea = Airrecord.table("api_key", "app_key", "Teas", batch_limit: 10)
+
+# An alternative to set batch_limit
+# Tea.batch_limit=(5)
+
+new_teas = [ { "Name" => "Assam Tea", "Type" => "Black" }, 
+             { "Name" => "Red Rooibos", "Type" => "Rooibos" },
+             { "Name" => "Dan Cong", "Type" => "Oolong" },
+             { "Name" => "Earl Grey Tea", "Type" => "Black"}
+]
+
+Tea.batch_create(new_teas)
+```
+
+If you need to manipulate a record before saving it, is recommended to use the `#create` method instead.
+
+**NOTE:** Column names must match the exact column names in Airtable,
+otherwise Airrecord will throw an error that no column matches it, as it happens to the `Table.create` method.
+
+_Earlier versions of airrecord provided methods for snake-cased column names
+and symbols, however this proved error-prone without a proper schema API from
+Airtable which has still not been released._
+
+
 ### Throttling
 
 Airtable's API enforces a 5 requests per second limit per client. In most cases,

--- a/lib/airrecord/table.rb
+++ b/lib/airrecord/table.rb
@@ -1,9 +1,12 @@
 require 'rubygems' # For Gem::Version
 
 module Airrecord
+  MAX_BATCH_LIMIT = 10
+  MAX_CHUNKS_LIMIT = 5
+
   class Table
     class << self
-      attr_accessor :base_key, :table_name
+      attr_accessor :base_key, :table_name, :batch_limit
       attr_writer :api_key
 
       def client
@@ -13,6 +16,20 @@ module Airrecord
 
       def api_key
         defined?(@api_key) ? @api_key : Airrecord.api_key
+      end
+
+      def batch_limit
+        fallback = defined?(Airrecord.batch_limit) ? Airrecord.batch_limit : MAX_BATCH_LIMIT
+        defined?(@batch_limit) ? @batch_limit : fallback
+      end
+
+      def batch_limit=(limit = MAX_BATCH_LIMIT)
+        @batch_limit = if !limit.is_a?(Integer) || limit > MAX_BATCH_LIMIT
+                         warn "Airreccord: We have set the value to the maximum batch size allowed, #{MAX_BATCH_LIMIT}."
+                         MAX_BATCH_LIMIT
+                       else
+                         limit
+                       end
       end
 
       def has_many(method_name, options)
@@ -51,13 +68,41 @@ module Airrecord
       def find_many(ids)
         return [] if ids.empty?
 
-        or_args = ids.map { |id| "RECORD_ID() = '#{id}'"}.join(',')
+        or_args = ids.map { |id| "RECORD_ID() = '#{id}'" }.join(',')
         formula = "OR(#{or_args})"
         records(filter: formula).sort_by { |record| or_args.index(record.id) }
       end
 
       def create(fields, options = {})
         new(fields).tap { |record| record.save(options) }
+      end
+
+      def batch_create(records, options = {})
+        raise TypeError, 'The records must be an Array' unless records.is_a? Array
+
+        chunks = records.each_slice(batch_limit).to_a
+
+        if chunks.size > MAX_CHUNKS_LIMIT
+          raise Error, "There are too many chunks, so they might block your requests. Max allowed: #{MAX_CHUNKS_LIMIT}"
+        end
+
+        path = "/v0/#{base_key}/#{client.escape(table_name)}"
+
+        chunks.each do |chunk|
+          serialized_chunks = chunk.map { |record| { fields: record } }
+
+          body = {
+            records: serialized_chunks,
+            **options
+          }.to_json
+
+          response = client.connection.post(path, body, { 'Content-Type' => 'application/json' })
+          parsed_response = client.parse(response.body)
+
+          return client.handle_error(response.status, parsed_response) unless response.success?
+        end
+
+        true
       end
 
       def records(filter: nil, sort: nil, view: nil, offset: nil, paginate: true, fields: nil, max_records: nil, page_size: nil)
@@ -104,6 +149,7 @@ module Airrecord
           client.handle_error(response.status, parsed_response)
         end
       end
+
       alias all records
     end
 
@@ -205,6 +251,7 @@ module Airrecord
       self.class == other.class &&
         serializable_fields == other.serializable_fields
     end
+
     alias eql? ==
 
     def hash
@@ -239,11 +286,12 @@ module Airrecord
     end
   end
 
-  def self.table(api_key, base_key, table_name)
+  def self.table(api_key, base_key, table_name, batch_limit: MAX_BATCH_LIMIT)
     Class.new(Table) do |klass|
       klass.table_name = table_name
       klass.api_key = api_key
       klass.base_key = base_key
+      klass.batch_limit = batch_limit
     end
   end
 end

--- a/lib/airrecord/table.rb
+++ b/lib/airrecord/table.rb
@@ -77,7 +77,7 @@ module Airrecord
         new(fields).tap { |record| record.save(options) }
       end
 
-      def batch_create(records, options = {})
+      def batch_create(records, options = {}, typecast: false)
         raise TypeError, 'The records must be an Array' unless records.is_a? Array
 
         chunks = records.each_slice(batch_limit).to_a
@@ -93,7 +93,8 @@ module Airrecord
 
           body = {
             records: serialized_chunks,
-            **options
+            **options,
+            typecast: typecast
           }.to_json
 
           response = client.connection.post(path, body, { 'Content-Type' => 'application/json' })

--- a/lib/airrecord/version.rb
+++ b/lib/airrecord/version.rb
@@ -1,3 +1,3 @@
 module Airrecord
-  VERSION = "1.0.8"
+  VERSION = "1.0.9"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,7 +11,7 @@ class Minitest::Test
     end
   end
 
-  def stub_post_request(record, table: @table, status: 200, headers: {}, options: {}, return_body: nil)
+  def stub_post_request(record, table: @table, status: 200, headers: {}, options: {}, return_body: nil, request_body: nil)
     return_body ||= {
       id: SecureRandom.hex(16),
       fields: record.serializable_fields,
@@ -19,10 +19,11 @@ class Minitest::Test
     }
     return_body = return_body.to_json
 
-    request_body = {
+    request_body ||= {
       fields: record.serializable_fields,
       **options,
-    }.to_json
+    }
+    request_body = request_body.to_json
 
     @stubs.post("/v0/#{table.base_key}/#{table.table_name}", request_body) do |env|
       [status, headers, return_body]


### PR DESCRIPTION
Hello ^^, This  is my first time opening a PR with a code change/addition, so I'm not sure if it'll be good enough...

I have created for anonymous  `Airrecord::Table` a method for creating multiple records at once passing an array `#batch_create`.
The idea is different from the idea commented on issue #66, because it's not an upsert so there is no validation if the record exist or not...

Anyway, I did this change for a project I'm working on and thought that this could be helpful to others...

Please let me know if you have any feedback about it.

This is an usage example:

```ruby
Tea = Airrecord.table("api_key", "app_key", "Teas", batch_limit: 10)
# An alternative to set batch_limit
# Tea.batch_limit=(5)

new_teas = [ { "Name" => "Assam Tea", "Type" => "Black" }, 
             { "Name" => "Red Rooibos", "Type" => "Rooibos" },
             { "Name" => "Dan Cong", "Type" => "Oolong" },
             { "Name" => "Earl Grey Tea", "Type" => "Black"}
]

Tea.batch_create(new_teas)
```

Thanks.