### PR TITLE
Allow Faraday v2

### DIFF
--- a/airrecord.gemspec
+++ b/airrecord.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.2"
 
-  spec.add_dependency "faraday", [">= 0.10", "< 2.0"]
+  spec.add_dependency "faraday", [">= 0.10", "< 3.0"]
   spec.add_dependency "net-http-persistent"
 
   spec.add_development_dependency "bundler", "~> 2"


### PR DESCRIPTION
This updates the gemspec to allow Faraday v2. The tests pass.