### PR TITLE
Add `faraday-net_http_persistent` gem as a dependency to fix a breaking change from faraday 2.0

### DIFF
--- a/airrecord.gemspec
+++ b/airrecord.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "faraday", [">= 0.10", "< 3.0"]
   spec.add_dependency "net-http-persistent"
+  spec.add_dependency "faraday-net_http_persistent"
 
   spec.add_development_dependency "bundler", "~> 2"
   spec.add_development_dependency "byebug"

--- a/lib/airrecord.rb
+++ b/lib/airrecord.rb
@@ -1,5 +1,6 @@
 require "json"
 require "faraday"
+require 'faraday/net_http_persistent'
 require "time"
 require "airrecord/version"
 require "airrecord/client"


### PR DESCRIPTION
- Add `faraday-net_http_persistent` gem as a dependency to fix a breaking change from faraday 2.0
- Resolves https://github.com/sirupsen/airrecord/issues/89