### PR TITLE
support batched delete requests

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,6 +11,13 @@ class Minitest::Test
     end
   end
 
+  def stub_delete_many_request(ids, table: @table, status: 202, response_body: "")
+    param = ids.map { |id| "records[]=#{id}" }.join('&')
+    @stubs.delete("/v0/#{@table.base_key}/#{@table.table_name}?#{param}") do |env|
+      [status, {}, response_body]
+    end
+  end
+
   def stub_post_request(record, table: @table, status: 200, headers: {}, options: {}, return_body: nil)
     return_body ||= {
       id: SecureRandom.hex(16),


### PR DESCRIPTION
Airtable supports batched requests for a number of operations. I would link to the docs but I can't seem to find any version of the docs that aren't base-specific.

Regardless, `DELETE` requests to `/v0/base_key/table_name?records[]=id1&records[]=id2...` allow deleting up to 10 records at a time. This PR adds support for that functionality.