### PR TITLE
Faraday v0.10 Ruby v3 Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 1.0.11
 * Update faraday_rate_limiter.rb to maintain compatibility with Faraday < 1 with Ruby 3 (#92).
 * Remove compatibility restriction from Gemfile.
+* No longer compatible with Faraday 2.
 
 # 1.0.10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.0.11
+* Update faraday_rate_limiter.rb to maintain compatibility with Faraday < 1 with Ruby 3 (#92).
+* Remove compatibility restriction from Gemfile.
+
 # 1.0.10
 
 * No longer compatible with Faraday < 1

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Airrecord
 
+## TED Fork of Airrecord
+This is a TED fork of Airrecord to maintain compatbility with Ruby 3 and Faraday v0.10.x.
+It *will not* work with Faraday v2. If you want Faraday v2 you need to go back to the main gem.
+
 Airrecord is an alternative Airtable Ruby libary to
 [`airtable-ruby`](https://github.com/airtable/airtable-ruby). Airrecord attempts
 to enforce a more [database-like API to

--- a/airrecord.gemspec
+++ b/airrecord.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "faraday", [">= 1.0", "< 3.0"]
   spec.add_dependency "net-http-persistent"
-  spec.add_dependency "faraday-net_http_persistent"
 
   spec.add_development_dependency "bundler", "~> 2"
   spec.add_development_dependency "byebug"

--- a/airrecord.gemspec
+++ b/airrecord.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.2"
 
-  spec.add_dependency "faraday", [">= 1.0", "< 3.0"]
+  spec.add_dependency "faraday", [">= 1.0", "< 2.0"]
   spec.add_dependency "net-http-persistent"
 
   spec.add_development_dependency "bundler", "~> 2"

--- a/lib/airrecord.rb
+++ b/lib/airrecord.rb
@@ -1,6 +1,5 @@
 require "json"
 require "faraday"
-require 'faraday/net_http_persistent'
 require "time"
 require "airrecord/version"
 require "airrecord/client"

--- a/lib/airrecord/version.rb
+++ b/lib/airrecord/version.rb
@@ -1,3 +1,3 @@
 module Airrecord
-  VERSION = "1.0.10"
+  VERSION = "1.0.11"
 end


### PR DESCRIPTION
This is a fix for getting Airrecord working with Faraday v0.10 on Ruby 3. See [ruby-lang.org](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/) for an explanation of the keyword arguments change that caused this.

There is no way to version/segment dependencies in a gemspec based on the version of Faraday according to StackOverflow, so I've chosen to just version constrain Faraday in this fork. In the alternative StackOverflow suggested I could add instructionst to the README if people wanted to use Faraday v2 with this fork and manually add the dep to their app Gemfile, but that seemed silly if you can just switch back to the main gem.