### PR TITLE
feat(update): create class update method to avoid API find call

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,8 +262,9 @@ Airtable which has still not been released._
 
 ### Updating
 
-Updating a record is done by changing the attributes and persistent to
-Airtable with `#save`.
+Updating can be done in two ways:
+
+1. With a record instance, change the attributes and persist to Airtable with `#save`
 
 ```ruby
 tea = Tea.find("someid")
@@ -271,6 +272,12 @@ tea["Name"] = "Feng Gang Organic"
 tea["Village"] = "Feng Gang"
 
 tea.save # persist to Airtable
+```
+
+2. With the `Table.update` class method (to save an API find call)
+
+```ruby
+Tea.update("someid", { "Name" => "Feng Gang Organic", "Village" => "Feng Gang" })
 ```
 
 _Airtable's API doesn't allow you to change attachment's filename. As a workaround you can delete the original attachment and [upload a new one](https://github.com/sirupsen/airrecord#file-uploads) with the original URL and a new filename._


### PR DESCRIPTION
With [the upcoming plan changes](https://support.airtable.com/docs/changes-to-airtable-plans), monthly API quota limits are being set, 1k for the free plan and 100k for the mid-level plan. This might be problematic for us, so I realized we could cut down almost 50% if we don't *always* require two API calls to sync record changes. Thus, I made a class `update` method that the instance `save` method uses, or can be used separately.

To test I did the following:

- Ran `record = OurTableKlass.find('recmBCJvI3hbRRo8c'); record["Name"] = "test change 1"; record.save` to see the record update in Airtable
- Sanity checked `record.fields`
- Ran `Airtable::Application.update('recmBCJvI3hbRRo8c', { "Name" => "test change 2" })` to see the record update again in Airtable